### PR TITLE
check for account existence first

### DIFF
--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -112,18 +112,6 @@ async function createAccount(options) {
         keyPair = await KeyPair.fromRandom('ed25519');
         publicKey = keyPair.getPublicKey();
     }
-    if (keyPair) {
-        // keyFilePath = near.connection.signer.keyStore.getKeyFilePath(options.networkId, options.accountId);
-
-        if (near.connection.signer.keyStore.keyStores.length) {
-            keyRootPath = near.connection.signer.keyStore.keyStores[0].keyDir;
-        }
-        keyFilePath = `${keyRootPath}/${options.networkId}/${options.accountId}.json`;
-        await near.connection.signer.keyStore.setKey(options.networkId, options.accountId, keyPair);
-        await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_END, { success: true, new_keypair: true }, options);
-    } else {
-        await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_END, { success: true, new_keypair: false }, options);
-    }
     // Check to see if account already exists
     try {
         // This is expected to error because the account shouldn't exist
@@ -133,6 +121,13 @@ async function createAccount(options) {
         if (!e.message.includes('does not exist while viewing')) {
             throw e;
         }
+    }
+    if (keyPair) {
+        if (near.connection.signer.keyStore.keyStores.length) {
+            keyRootPath = near.connection.signer.keyStore.keyStores[0].keyDir;
+        }
+        keyFilePath = `${keyRootPath}/${options.networkId}/${options.accountId}.json`;
+        await near.connection.signer.keyStore.setKey(options.networkId, options.accountId, keyPair);
     }
     // Create account
     console.log(`Saving key to '${keyFilePath}'`);

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -2,7 +2,6 @@
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const { KeyPair } = require('near-api-js');
-const eventtracking = require('../utils/eventtracking');
 const inspectResponse = require('../utils/inspect-response');
 // Top-level account (TLA) is testnet for foo.alice.testnet
 const TLA_MIN_LENGTH = 32;


### PR DESCRIPTION
Quick fix for issue described here:

> earlier today I was using near cli to create a subaccount of the
> masterAccount in betanet. I came across of what seems to be as a
> critical error:
> 1) I accidentally ran "near create-account .." twice. And naturally got the error
> 'Sorry, account \'bugged.validator_italia.betanet\' already exists.'
> Nothing strange so far.
> 2)
>  However, after this error I was locked out of my subaccount and
> couldn't get my fonds out. I even tried copying the .json files with the
>  keys to a different server (which is still using near shell) and still
> couldn't sign any transactions with my subaccount. The error message I
> get is now
> 'Can not sign transactions for account bugged.validator_italia.betanet, no matching key pair found in Signer.',
> 3)
>  I tried this workflow with 3 different subaccounts and every time I was
>  locked out of the account. I attach a picture of the workflow to this
> email