### PR TITLE
Implement add-key option

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -228,6 +228,7 @@ yargs // eslint-disable-line
     .command(login)
     .command(require('../commands/repl'))
     .command(require('../commands/generate-key'))
+    .command(require('../commands/add-key'))
     .command(require('../commands/delete-key'))
     .command(require('../commands/validators'))
     .command(require('../commands/proposals'))

--- a/commands/add-key.js
+++ b/commands/add-key.js
@@ -1,0 +1,44 @@
+const BN = require('bn.js');
+const exitOnError = require('../utils/exit-on-error');
+const connect = require('../utils/connect');
+const inspectResponse = require('../utils/inspect-response');
+const { utils } = require('near-api-js');
+
+module.exports = {
+    command: 'add-key [access-key]',
+    desc: 'Add an access key to given account',
+    builder: (yargs) => yargs
+        .option('access-key', {
+            desc: 'Public key to add (base58 encoded)',
+            type: 'string',
+            required: true,
+        })
+        .option('contract-id', {
+            desc: 'Limit access key to given contract (if not provided - will create full access key)',
+            type: 'string',
+            required: false,
+        })
+        .option('method-names', {
+            desc: 'Method names to limit access key to (command separated)',
+            type: 'string',
+            required: false,
+        })
+        .option('allowance', {
+            desc: 'Allowance on the key (default 0)',
+            type: 'string',
+            required: false,
+        }),
+    handler: exitOnError(addAccessKey)
+};
+
+async function addAccessKey(options) {
+    if (!options.accountId) {
+        return;
+    }
+    console.log(`Adding ${options.contractId ? 'limited access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
+    const near = await connect(options);
+    const account = await near.account(options.accountId);
+    const allowance = utils.format.parseNearAmount(options.allowance);
+    const result = await account.addKey(options.accessKey, options.contractId, options.methodNames, allowance);
+    inspectResponse.prettyPrintResponse(result, options);
+}

--- a/commands/add-key.js
+++ b/commands/add-key.js
@@ -4,7 +4,7 @@ const inspectResponse = require('../utils/inspect-response');
 const { utils } = require('near-api-js');
 
 module.exports = {
-    command: 'add-key [access-key]',
+    command: 'add-key <account-id> <access-key>',
     desc: 'Add an access key to given account',
     builder: (yargs) => yargs
         .option('access-key', {
@@ -31,9 +31,6 @@ module.exports = {
 };
 
 async function addAccessKey(options) {
-    if (!options.accountId) {
-        return;
-    }
     console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/add-key.js
+++ b/commands/add-key.js
@@ -1,4 +1,3 @@
-const BN = require('bn.js');
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
@@ -24,7 +23,7 @@ module.exports = {
             required: false,
         })
         .option('allowance', {
-            desc: 'Allowance on the key (default 0)',
+            desc: 'Allowance in $NEAR for the key (default 0)',
             type: 'string',
             required: false,
         }),
@@ -35,7 +34,7 @@ async function addAccessKey(options) {
     if (!options.accountId) {
         return;
     }
-    console.log(`Adding ${options.contractId ? 'limited access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
+    console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const allowance = utils.format.parseNearAmount(options.allowance);

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -3,10 +3,10 @@ const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
 
 module.exports = {
-    command: 'delete-key [accessKey]',
+    command: 'delete-key <account-id> <access-key>',
     desc: 'delete access key',
     builder: (yargs) => yargs
-        .option('accessKey', {
+        .option('access-key', {
             desc: 'Public key to delete (base58 encoded)',
             type: 'string',
             required: true,


### PR DESCRIPTION
Fixes #513 

Usage:

Adding full access key to `illia` account:
```
near add-key CaSbwUJy2WEKKHHYnd6F7ZXUVUJ3AAzLBbDmvqML3jBg --account-id illia
```

Adding function access key to `illia` account for contract `test`, method name `deploy`, allowance: `1` $NEAR:
```
./bin/near add-key CaSbwUJy2WEKKHHYnd6F7ZXUVUJ3AAzLBbDmvqML3jBg --account-id illia --contract-id test --method-names deploy --allowance 1
```

PS. Where are we suppose to update documentation for this? @mikedotexe @potatodepaulo @amgando 