### PR TITLE
Don't use colors if stdout is not a terminal

### DIFF
--- a/utils/inspect-response.js
+++ b/utils/inspect-response.js
@@ -24,7 +24,12 @@ const prettyPrintError = (error, options) => {
 };
 
 const formatResponse = (response) => {
-    return util.inspect(response, { showHidden: true, depth: null, colors: true, maxArrayLength: null });
+    return util.inspect(response, {
+        showHidden: true,
+        depth: null,
+        colors: Boolean(process.stdout.isTTY && process.stdout.hasColors()),
+        maxArrayLength: null
+    });
 };
 
 const getTxnIdFromError = (error) => {


### PR DESCRIPTION
This helps when greping, awking or seding stdout. Colors escape sequences make it difficult.
