### PR TITLE
fix #503 adds --memo option to 'call' command

### DIFF
--- a/commands/call.js
+++ b/commands/call.js
@@ -28,14 +28,14 @@ module.exports = {
             type: 'string',
         })
         .option('memo', {
-            desc: 'send a text memo instead of json params (e.g. \'near call exchange deposit --memo \'USER_123\' --amount 10\')',
+            desc: 'send a text memo instead of json params (e.g. >near call exchange deposit --memo \'USER_123\' --amount 10)',
             type: 'string',
         }),
     handler: exitOnError(scheduleFunctionCall)
 };
 
 async function scheduleFunctionCall(options) {
-    if (options.memo) options.args=`{"":"${options.memo}"}`
+    if (options.memo) options.args=`{"":"${options.memo}"}`;
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
         (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);

--- a/commands/call.js
+++ b/commands/call.js
@@ -26,11 +26,16 @@ module.exports = {
             required: true,
             desc: 'Unique identifier for the account that will be used to sign this call',
             type: 'string',
+        })
+        .option('memo', {
+            desc: 'send a text memo instead of json params (e.g. \'near call exchange deposit --memo \'USER_123\' --amount 10\')',
+            type: 'string',
         }),
     handler: exitOnError(scheduleFunctionCall)
 };
 
 async function scheduleFunctionCall(options) {
+    if (options.memo) options.args=`{"":"${options.memo}"}`
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
         (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);


### PR DESCRIPTION
with this addition, the exchange-hot-wallet contract call mentioned in #503 by @evgenykuzyakov becomes:

`near call exchange.m0 exchange_deposit --memo 'USER_123' --accountId=m0 --amount=0.1`

