### PR TITLE
Save account credentials with generate-key --seedPhrase option

### DIFF
--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -35,6 +35,9 @@ module.exports = {
             argv.publicKey = keyPair.publicKey.toString();
             argv.accountId = argv.accountId || implicitAccountId(argv.publicKey);
             await keyStore.setKey(argv.networkId, argv.accountId, keyPair);
+        } else if (argv.seedPhrase) {
+            const seededKeyPair = await argv.signer.keyStore.getKey(argv.networkId, argv.accountId);
+            await keyStore.setKey(argv.networkId, argv.accountId, seededKeyPair);
         }
             
         console.log(`Key pair with ${argv.publicKey} public key for an account "${argv.accountId}"`);


### PR DESCRIPTION
I was able to generate account.json credentials file from seed phrase,
received when I was initially setting up account via official NEAR web
wallet.

      env NODE_ENV=mainnet near generate-key --seedPhrase 'secret recovery phrase' account

I find it very convenient. This addresses https://github.com/near/near-cli/issues/570