### PR TITLE
Add evm-dev-init command to create test accounts

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -246,6 +246,7 @@ yargs // eslint-disable-line
     .command(require('../commands/validators'))
     .command(require('../commands/proposals'))
     .command(require('../commands/evm-call'))
+    .command(require('../commands/evm-dev-init'))
     .command(require('../commands/evm-view'))
     .config(config)
     .alias({

--- a/commands/evm-dev-init.js
+++ b/commands/evm-dev-init.js
@@ -1,0 +1,26 @@
+const exitOnError = require('../utils/exit-on-error');
+const { utils } = require('near-web3-provider');
+const connect = require('../utils/connect');
+
+module.exports = {
+    command: 'evm-dev-init <accountId> [numAccounts]',
+    desc: 'Creates test accounts using NEAR Web3 Provider',
+    builder: (yargs) => yargs
+        .option('accountId', {
+            desc: 'NEAR account creating the test subaccounts',
+            type: 'string',
+            default: '0'
+        })
+        .option('numAccounts', {
+            desc: 'Number of test accounts to create',
+            type: 'number',
+            default: '5'
+        }),
+    handler: exitOnError(scheduleEVMDevInit)
+};
+
+async function scheduleEVMDevInit(options) {
+    const near = await connect(options);
+    const account = await near.account(options.accountId);
+    await utils.createTestAccounts(account, options.numAccounts);
+}


### PR DESCRIPTION
Well after looking into proper subcommands in yargs, it ended up not being what's going to work for us. 
Some reading:
https://stackoverflow.com/questions/59894389/how-to-implement-multiple-subcommands-with-yargs
https://laurieontech.com/posts/yargs/
https://github.com/yargs/yargs/blob/master/docs/advanced.md#variadic-positional-arguments

It really doesn't work well with the `--help` flag. I think yargs is essentially not good at having subcommands that take different flags.
I'd like to focus on getting the network config in near-web3-provider, so I'm going to put a fork in this.
Arto, I know you're working on more difficult tasks, don't feel pressure to take your time. This one is super straight forward and I'm happy to merge it after some cursory eyes.