### PR TITLE
deprecate default folder

### DIFF
--- a/commands/add-key.js
+++ b/commands/add-key.js
@@ -32,7 +32,7 @@ module.exports = {
 };
 
 async function addAccessKey(options) {
-    await checkCredentials(options.account_id, options.network_id, options.keyStore);
+    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/add-key.js
+++ b/commands/add-key.js
@@ -4,7 +4,6 @@ const inspectResponse = require('../utils/inspect-response');
 const { utils } = require('near-api-js');
 const checkCredentials = require('../utils/check-credentials');
 
-
 module.exports = {
     command: 'add-key <account-id> <access-key>',
     desc: 'Add an access key to given account',

--- a/commands/add-key.js
+++ b/commands/add-key.js
@@ -32,7 +32,7 @@ module.exports = {
 };
 
 async function addAccessKey(options) {
-    checkCredentials(options);
+    checkCredentials(options.accountId, options.network, options.keystore);
     console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/add-key.js
+++ b/commands/add-key.js
@@ -32,7 +32,7 @@ module.exports = {
 };
 
 async function addAccessKey(options) {
-    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/add-key.js
+++ b/commands/add-key.js
@@ -32,7 +32,7 @@ module.exports = {
 };
 
 async function addAccessKey(options) {
-    checkCredentials(options.accountId, options.network, options.keystore);
+    await checkCredentials(options.account_id, options.network_id, options.keyStore);
     console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/add-key.js
+++ b/commands/add-key.js
@@ -2,6 +2,7 @@ const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
 const { utils } = require('near-api-js');
+const checkCredentials = require('../utils/check-credentials');
 
 
 module.exports = {
@@ -32,6 +33,7 @@ module.exports = {
 };
 
 async function addAccessKey(options) {
+    checkCredentials(options);
     console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/call.js
+++ b/commands/call.js
@@ -37,7 +37,7 @@ module.exports = {
 };
 
 async function scheduleFunctionCall(options) {
-    await checkCredentials(options.account_id, options.network_id, options.keyStore);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
         (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);

--- a/commands/call.js
+++ b/commands/call.js
@@ -37,7 +37,7 @@ module.exports = {
 };
 
 async function scheduleFunctionCall(options) {
-    await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
         (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);

--- a/commands/call.js
+++ b/commands/call.js
@@ -37,7 +37,7 @@ module.exports = {
 };
 
 async function scheduleFunctionCall(options) {
-    await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    await checkCredentials(options.account_id, options.network_id, options.keyStore);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
         (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);

--- a/commands/call.js
+++ b/commands/call.js
@@ -37,7 +37,7 @@ module.exports = {
 };
 
 async function scheduleFunctionCall(options) {
-    checkCredentials(options);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
         (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);

--- a/commands/call.js
+++ b/commands/call.js
@@ -37,7 +37,7 @@ module.exports = {
 };
 
 async function scheduleFunctionCall(options) {
-    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
         (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);

--- a/commands/call.js
+++ b/commands/call.js
@@ -2,6 +2,7 @@ const { providers, utils } = require('near-api-js');
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
+const checkCredentials = require('../utils/check-credentials');
 
 module.exports = {
     command: 'call <contractName> <methodName> [args]',
@@ -36,6 +37,7 @@ module.exports = {
 };
 
 async function scheduleFunctionCall(options) {
+    checkCredentials(options);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
         (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -3,6 +3,7 @@ const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const { KeyPair } = require('near-api-js');
 const inspectResponse = require('../utils/inspect-response');
+const checkCredentials = require('../utils/check-credentials');
 // Top-level account (TLA) is testnet for foo.alice.testnet
 const TLA_MIN_LENGTH = 32;
 
@@ -74,6 +75,7 @@ const createAccountCommandDeprecated = {
 async function createAccount(options) {
     // NOTE: initialBalance is passed as part of config here, parsed in middleware/initial-balance
     // periods are disallowed in top-level accounts and can only be used for subaccounts
+    checkCredentials(options);
     const splitAccount = options.accountId.split('.');
 
     const splitMaster = options.masterAccount.split('.');

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -73,7 +73,7 @@ const createAccountCommandDeprecated = {
 }; 
 
 async function createAccount(options) {
-    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.masterAccount, options.networkId, options.keyStore);
+    await checkCredentials(options.masterAccount, options.networkId, options.keyStore);
     // NOTE: initialBalance is passed as part of config here, parsed in middleware/initial-balance
     // periods are disallowed in top-level accounts and can only be used for subaccounts
     const splitAccount = options.accountId.split('.');

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -73,11 +73,10 @@ const createAccountCommandDeprecated = {
 }; 
 
 async function createAccount(options) {
+    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.masterAccount, options.networkId, options.keyStore);
     // NOTE: initialBalance is passed as part of config here, parsed in middleware/initial-balance
     // periods are disallowed in top-level accounts and can only be used for subaccounts
-    await checkCredentials(options.masterAccount, options.networkId, options.keyStore);
     const splitAccount = options.accountId.split('.');
-
     const splitMaster = options.masterAccount.split('.');
     const masterRootTLA = splitMaster[splitMaster.length - 1];
     if (splitAccount.length === 1) {

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -75,7 +75,7 @@ const createAccountCommandDeprecated = {
 async function createAccount(options) {
     // NOTE: initialBalance is passed as part of config here, parsed in middleware/initial-balance
     // periods are disallowed in top-level accounts and can only be used for subaccounts
-    checkCredentials(options);
+    await checkCredentials(options.masterAccount, options.networkId, options.keyStore);
     const splitAccount = options.accountId.split('.');
 
     const splitMaster = options.masterAccount.split('.');

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -1,6 +1,7 @@
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
+const checkCredentials = require('../utils/check-credentials');
 
 module.exports = {
     command: 'delete-key <account-id> <access-key>',
@@ -15,6 +16,7 @@ module.exports = {
 };
 
 async function deleteAccessKey(options) {
+    checkCredentials(options);
     console.log(`Deleting key = ${options.accessKey} on ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -16,7 +16,7 @@ module.exports = {
 };
 
 async function deleteAccessKey(options) {
-    checkCredentials(options);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Deleting key = ${options.accessKey} on ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -16,7 +16,7 @@ module.exports = {
 };
 
 async function deleteAccessKey(options) {
-    await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Deleting key = ${options.accessKey} on ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -16,7 +16,7 @@ module.exports = {
 };
 
 async function deleteAccessKey(options) {
-    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Deleting key = ${options.accessKey} on ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/evm-call.js
+++ b/commands/evm-call.js
@@ -37,7 +37,7 @@ module.exports = {
 };
 
 async function scheduleEVMFunctionCall(options) {
-    checkCredentials(options);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     const args = JSON.parse(options.args || '[]');
     console.log(`Scheduling a call inside ${options.evmAccount} EVM:`);
     console.log(`${options.contractName}.${options.methodName}()` +

--- a/commands/evm-call.js
+++ b/commands/evm-call.js
@@ -2,6 +2,7 @@ const exitOnError = require('../utils/exit-on-error');
 const web3 = require('web3');
 const { NearProvider, utils } = require('near-web3-provider');
 const assert = require('assert');
+const checkCredentials = require('../utils/check-credentials');
 
 module.exports = {
     command: 'evm-call <evmAccount> <contractName> <methodName> [args]',
@@ -36,6 +37,7 @@ module.exports = {
 };
 
 async function scheduleEVMFunctionCall(options) {
+    checkCredentials(options);
     const args = JSON.parse(options.args || '[]');
     console.log(`Scheduling a call inside ${options.evmAccount} EVM:`);
     console.log(`${options.contractName}.${options.methodName}()` +

--- a/commands/evm-call.js
+++ b/commands/evm-call.js
@@ -37,7 +37,7 @@ module.exports = {
 };
 
 async function scheduleEVMFunctionCall(options) {
-    await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
     const args = JSON.parse(options.args || '[]');
     console.log(`Scheduling a call inside ${options.evmAccount} EVM:`);
     console.log(`${options.contractName}.${options.methodName}()` +

--- a/commands/evm-call.js
+++ b/commands/evm-call.js
@@ -37,7 +37,7 @@ module.exports = {
 };
 
 async function scheduleEVMFunctionCall(options) {
-    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     const args = JSON.parse(options.args || '[]');
     console.log(`Scheduling a call inside ${options.evmAccount} EVM:`);
     console.log(`${options.contractName}.${options.methodName}()` +

--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ function getConfig(env) {
     case 'development':
     case 'testnet':
         return {
-            networkId: 'default',
+            networkId: 'testnet',
             nodeUrl: 'https://rpc.testnet.near.org',
             contractName: CONTRACT_NAME,
             walletUrl: 'https://wallet.testnet.near.org',

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ exports.clean = async function () {
 };
 
 exports.deploy = async function (options) {
-    await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(
         `Starting deployment. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, file: ${options.wasmFile}`);
 
@@ -190,7 +190,7 @@ exports.viewAccount = async function (options) {
 };
 
 exports.deleteAccount = async function (options) {
-    await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(
         `Deleting account. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, beneficiary: ${options.beneficiaryId}`);
     const near = await connect(options);
@@ -209,7 +209,7 @@ exports.keys = async function (options) {
 };
 
 exports.sendMoney = async function (options) {
-    await checkCredentials(options.sender, options.networkId, options.keyStore);
+    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.sender, options.networkId, options.keyStore);
     console.log(`Sending ${options.amount} NEAR to ${options.receiver} from ${options.sender}`);
     const near = await connect(options);
     const account = await near.account(options.sender);
@@ -218,7 +218,7 @@ exports.sendMoney = async function (options) {
 };
 
 exports.stake = async function (options) {
-    await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Staking ${options.amount} (${utils.format.parseNearAmount(options.amount)}) on ${options.accountId} with public key = ${qs.unescape(options.stakingKey)}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const capture = require('./utils/capture-login-success');
 
 const inspectResponse = require('./utils/inspect-response');
 const eventtracking = require('./utils/eventtracking');
+const checkCredentials = require('./utils/check-credentials');
 
 // TODO: Fix promisified wrappers to handle error properly
 
@@ -30,6 +31,7 @@ exports.clean = async function () {
 };
 
 exports.deploy = async function (options) {
+    checkCredentials(options);
     console.log(
         `Starting deployment. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, file: ${options.wasmFile}`);
 
@@ -64,11 +66,14 @@ exports.deploy = async function (options) {
 };
 
 exports.callViewFunction = async function (options) {
+    checkCredentials(options);
     console.log(`View call: ${options.contractName}.${options.methodName}(${options.args || ''})`);
     const near = await connect(options);
     const account = await near.account(options.accountId || options.masterAccount || options.contractName);
     console.log(inspectResponse.formatResponse(await account.viewFunction(options.contractName, options.methodName, JSON.parse(options.args || '{}'))));
 };
+
+
 
 // open a given URL in browser in a safe way.
 const openUrl = async function(url) {
@@ -186,6 +191,7 @@ exports.viewAccount = async function (options) {
 };
 
 exports.deleteAccount = async function (options) {
+    checkCredentials(options);
     console.log(
         `Deleting account. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, beneficiary: ${options.beneficiaryId}`);
     const near = await connect(options);
@@ -204,6 +210,7 @@ exports.keys = async function (options) {
 };
 
 exports.sendMoney = async function (options) {
+    checkCredentials(options);
     console.log(`Sending ${options.amount} NEAR to ${options.receiver} from ${options.sender}`);
     const near = await connect(options);
     const account = await near.account(options.sender);
@@ -212,6 +219,7 @@ exports.sendMoney = async function (options) {
 };
 
 exports.stake = async function (options) {
+    checkCredentials(options);
     console.log(`Staking ${options.amount} (${utils.format.parseNearAmount(options.amount)}) on ${options.accountId} with public key = ${qs.unescape(options.stakingKey)}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ exports.keys = async function (options) {
 };
 
 exports.sendMoney = async function (options) {
-    checkCredentials(options);
+    await checkCredentials(options.sender, options.networkId, options.keyStore);
     console.log(`Sending ${options.amount} NEAR to ${options.receiver} from ${options.sender}`);
     const near = await connect(options);
     const account = await near.account(options.sender);

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ exports.clean = async function () {
 };
 
 exports.deploy = async function (options) {
-    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(
         `Starting deployment. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, file: ${options.wasmFile}`);
 
@@ -190,7 +190,7 @@ exports.viewAccount = async function (options) {
 };
 
 exports.deleteAccount = async function (options) {
-    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(
         `Deleting account. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, beneficiary: ${options.beneficiaryId}`);
     const near = await connect(options);
@@ -209,7 +209,7 @@ exports.keys = async function (options) {
 };
 
 exports.sendMoney = async function (options) {
-    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.sender, options.networkId, options.keyStore);
+    await checkCredentials(options.sender, options.networkId, options.keyStore);
     console.log(`Sending ${options.amount} NEAR to ${options.receiver} from ${options.sender}`);
     const near = await connect(options);
     const account = await near.account(options.sender);
@@ -218,7 +218,7 @@ exports.sendMoney = async function (options) {
 };
 
 exports.stake = async function (options) {
-    if(options.networkId === 'default' | 'testnet') await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Staking ${options.amount} (${utils.format.parseNearAmount(options.amount)}) on ${options.accountId} with public key = ${qs.unescape(options.stakingKey)}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/index.js
+++ b/index.js
@@ -72,8 +72,6 @@ exports.callViewFunction = async function (options) {
     console.log(inspectResponse.formatResponse(await account.viewFunction(options.contractName, options.methodName, JSON.parse(options.args || '{}'))));
 };
 
-
-
 // open a given URL in browser in a safe way.
 const openUrl = async function(url) {
     try {

--- a/index.js
+++ b/index.js
@@ -66,7 +66,6 @@ exports.deploy = async function (options) {
 };
 
 exports.callViewFunction = async function (options) {
-    checkCredentials(options);
     console.log(`View call: ${options.contractName}.${options.methodName}(${options.args || ''})`);
     const near = await connect(options);
     const account = await near.account(options.accountId || options.masterAccount || options.contractName);

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ exports.clean = async function () {
 };
 
 exports.deploy = async function (options) {
-    checkCredentials(options);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(
         `Starting deployment. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, file: ${options.wasmFile}`);
 

--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ exports.viewAccount = async function (options) {
 };
 
 exports.deleteAccount = async function (options) {
-    checkCredentials(options);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(
         `Deleting account. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, beneficiary: ${options.beneficiaryId}`);
     const near = await connect(options);
@@ -218,7 +218,7 @@ exports.sendMoney = async function (options) {
 };
 
 exports.stake = async function (options) {
-    checkCredentials(options);
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Staking ${options.amount} (${utils.format.parseNearAmount(options.amount)}) on ${options.accountId} with public key = ${qs.unescape(options.stakingKey)}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/utils/check-credentials.js
+++ b/utils/check-credentials.js
@@ -1,3 +1,6 @@
+const homedir = require('os').homedir();
+const credentials_dir = homedir + '/.near-credentials';
+
 module.exports = async function checkCredentials(options) {
   if(!(await options.keyStore.getKey(options.networkId, options.accountId))) {
     console.log(`Unable to find ${options.networkId} credentials for ${options.accountId}`);
@@ -6,11 +9,11 @@ module.exports = async function checkCredentials(options) {
         const answer = await askYesNoQuestion('Key found in deprecated \'default\' folder. Would you like to move key to \'testnet\' folder? (y/n): ', false);
         if(answer) {
             console.log('Moving files...');
-            // await fs.copyFile(`${credPath}/default/${option.accountId}`, `${credPath}/${options.networkId}/${options.accountId}`)
+            await fs.copyFile(`${credentials_dir}/default/${option.accountId}`, `${credentials_dir}/testnet/${options.accountId}`)
         } else {
-            console.log('Please relocate credentials found in \'default\' directory to \'testnet\'');
+            console.log('Please relocate credentials found in \'default\' directory to \'testnet\'.');
             return;
         }
     }
   }
-};
+}

--- a/utils/check-credentials.js
+++ b/utils/check-credentials.js
@@ -1,23 +1,28 @@
 const homedir = require('os').homedir();
 const credentials_dir = homedir + '/.near-credentials';
-const fs = require('fs').promises;
 const { askYesNoQuestion } = require('./readline');
 
-module.exports = async function checkCredentials(accountId, networkId, keyStore) {
-  console.log('networkId', networkId);
-  console.log('accountId', accountId);
-  if(!(await keyStore.getKey(networkId, accountId))) {
-    console.log(`Unable to find ${networkId} credentials for ${accountId}`);
-    const hasInDefault = await keyStore.getKey('default', accountId);
-    if(hasInDefault) {
-        const answer = await askYesNoQuestion('Key found in deprecated \'default\' folder. Would you like to move key to \'testnet\' folder? (y/n): ', false);
-        if(answer) {
-            console.log('Moving files...');
-            await fs.copyFile(`${credentials_dir}/default/${accountId}.json`, `${credentials_dir}/testnet/${accountId}.json`)
-            throw ('Please run command again.')
-        } else {
-            throw ('Please relocate credentials found in \'default\' directory to \'testnet\'.');
-        }
-    } else throw ('error')
-  }
-}
+module.exports = async function checkCredentials(
+    accountId,
+    networkId,
+    keyStore
+) {
+    if (!(await keyStore.getKey(networkId, accountId))) {
+        console.log(
+            `Unable to find [ ${networkId} ] credentials for [ ${accountId} ]`
+        );
+        const defaultKeyPair = await keyStore.getKey('default', accountId);
+        if (defaultKeyPair) {
+            const answer = await askYesNoQuestion(
+                'Key found in deprecated [ default ] folder. Would you like to move key to [ testnet ] folder? (y/n): ',
+                false
+            );
+            if (answer) {
+                console.log('Moving key and retrying transaction...');
+                await keyStore.setKey('testnet', accountId, defaultKeyPair);
+            } else {
+                throw 'Please relocate credentials found in [ default ] directory to [ testnet ] directory.';
+            }
+        } else throw 'error';
+    }
+};

--- a/utils/check-credentials.js
+++ b/utils/check-credentials.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk');
 const { askYesNoQuestion } = require('./readline');
 
 module.exports = async function checkCredentials(
@@ -5,27 +6,29 @@ module.exports = async function checkCredentials(
     networkId,
     keyStore
 ) {
-    if(networkId !== 'testnet' || networkId !== 'default') return;
+    if(networkId !== 'testnet' && networkId !== 'default') return;
     if (!(await keyStore.getKey(networkId, accountId))) {
         console.log(
-            `Unable to find [ ${networkId} ] credentials for [ ${accountId} ]`
+            chalk`{bold.white Unable to find [ ${networkId} ] credentials for [ ${accountId} ]}`
         );
         const testnetKeys = await keyStore.getKey('testnet', accountId);
         const defaultKeys = await keyStore.getKey('default', accountId);
         if (defaultKeys && networkId === 'testnet') {
             const answer = await askYesNoQuestion(
-                'Key found in deprecated [ default ] folder. Would you like to copy your key to [ testnet ] folder? (y/n): ',
+                chalk`{bold.white Key found in {bold.yellow deprecated} [ default ] folder. Would you like to copy your key to [ testnet ] folder? (y/n)}`,
                 false
             );
             if (answer) {
-                console.log('Copying key and retrying transaction...');
-                await keyStore.setKey('testnet', accountId);
+                console.log(chalk`{bold.white Copying key and attempting transaction...}`);
+                await keyStore.setKey('testnet', accountId, defaultKeys);
             } else {
-                throw 'Please relocate credentials found in [ default ] directory to [ testnet ] directory.';
+                throw console.log(
+                    chalk`{bold.white Please relocate credentials found in [ default ] directory to [ testnet ] directory.}`
+                );
             }
         } else if (testnetKeys && networkId === 'default') {
             console.log(
-                'Key found in [ testnet ] folder but your command is configured to use deprecated [ default ] network. Please upgrade near-cli or change your project\'s config file. '
+                chalk`{bold.white Key found in [ testnet ] folder but your command is configured to use {bold.yellow deprecated} [ default ] network. Please upgrade near-cli or change your project\'s config file. }`
             );
         }
     }

--- a/utils/check-credentials.js
+++ b/utils/check-credentials.js
@@ -1,0 +1,16 @@
+module.exports = async function checkCredentials(options) {
+  if(!(await options.keyStore.getKey(options.networkId, options.accountId))) {
+    console.log(`Unable to find ${options.networkId} credentials for ${options.accountId}`);
+    const hasInDefault = await options.keyStore.getKey('default', options.accountId);
+    if(hasInDefault) {
+        const answer = await askYesNoQuestion('Key found in deprecated \'default\' folder. Would you like to move key to \'testnet\' folder? (y/n): ', false);
+        if(answer) {
+            console.log('Moving files...');
+            // await fs.copyFile(`${credPath}/default/${option.accountId}`, `${credPath}/${options.networkId}/${options.accountId}`)
+        } else {
+            console.log('Please relocate credentials found in \'default\' directory to \'testnet\'');
+            return;
+        }
+    }
+  }
+};

--- a/utils/check-credentials.js
+++ b/utils/check-credentials.js
@@ -5,6 +5,7 @@ module.exports = async function checkCredentials(
     networkId,
     keyStore
 ) {
+    if(networkId != 'testnet' || networkId != 'default') return;
     if (!(await keyStore.getKey(networkId, accountId))) {
         console.log(
             `Unable to find [ ${networkId} ] credentials for [ ${accountId} ]`

--- a/utils/check-credentials.js
+++ b/utils/check-credentials.js
@@ -1,19 +1,23 @@
 const homedir = require('os').homedir();
 const credentials_dir = homedir + '/.near-credentials';
+const fs = require('fs').promises;
+const { askYesNoQuestion } = require('./readline');
 
-module.exports = async function checkCredentials(options) {
-  if(!(await options.keyStore.getKey(options.networkId, options.accountId))) {
-    console.log(`Unable to find ${options.networkId} credentials for ${options.accountId}`);
-    const hasInDefault = await options.keyStore.getKey('default', options.accountId);
+module.exports = async function checkCredentials(accountId, networkId, keyStore) {
+  console.log('networkId', networkId);
+  console.log('accountId', accountId);
+  if(!(await keyStore.getKey(networkId, accountId))) {
+    console.log(`Unable to find ${networkId} credentials for ${accountId}`);
+    const hasInDefault = await keyStore.getKey('default', accountId);
     if(hasInDefault) {
         const answer = await askYesNoQuestion('Key found in deprecated \'default\' folder. Would you like to move key to \'testnet\' folder? (y/n): ', false);
         if(answer) {
             console.log('Moving files...');
-            await fs.copyFile(`${credentials_dir}/default/${option.accountId}`, `${credentials_dir}/testnet/${options.accountId}`)
+            await fs.copyFile(`${credentials_dir}/default/${accountId}.json`, `${credentials_dir}/testnet/${accountId}.json`)
+            throw ('Please run command again.')
         } else {
-            console.log('Please relocate credentials found in \'default\' directory to \'testnet\'.');
-            return;
+            throw ('Please relocate credentials found in \'default\' directory to \'testnet\'.');
         }
-    }
+    } else throw ('error')
   }
 }

--- a/utils/check-credentials.js
+++ b/utils/check-credentials.js
@@ -1,5 +1,3 @@
-const homedir = require('os').homedir();
-const credentials_dir = homedir + '/.near-credentials';
 const { askYesNoQuestion } = require('./readline');
 
 module.exports = async function checkCredentials(

--- a/utils/check-credentials.js
+++ b/utils/check-credentials.js
@@ -12,11 +12,11 @@ module.exports = async function checkCredentials(
         const defaultKeyPair = await keyStore.getKey('default', accountId);
         if (defaultKeyPair) {
             const answer = await askYesNoQuestion(
-                'Key found in deprecated [ default ] folder. Would you like to move key to [ testnet ] folder? (y/n): ',
+                'Key found in deprecated [ default ] folder. Would you like to copy your key to [ testnet ] folder? (y/n): ',
                 false
             );
             if (answer) {
-                console.log('Moving key and retrying transaction...');
+                console.log('Copying key and retrying transaction...');
                 await keyStore.setKey('testnet', accountId, defaultKeyPair);
             } else {
                 throw 'Please relocate credentials found in [ default ] directory to [ testnet ] directory.';

--- a/utils/check-credentials.js
+++ b/utils/check-credentials.js
@@ -9,13 +9,13 @@ module.exports = async function checkCredentials(
     if(networkId !== 'testnet' && networkId !== 'default') return;
     if (!(await keyStore.getKey(networkId, accountId))) {
         console.log(
-            chalk`{bold.white Unable to find [ ${networkId} ] credentials for [ ${accountId} ]}`
+            chalk`{bold.white Unable to find [ {bold.blue ${networkId}} ] credentials for [ {bold.blue ${accountId}} ]...}`
         );
         const testnetKeys = await keyStore.getKey('testnet', accountId);
         const defaultKeys = await keyStore.getKey('default', accountId);
         if (defaultKeys && networkId === 'testnet') {
             const answer = await askYesNoQuestion(
-                chalk`{bold.white Key found in {bold.yellow deprecated} [ default ] folder. Would you like to copy your key to [ testnet ] folder? (y/n)}`,
+                chalk`{bold.white Key found in {bold.yellow deprecated} [ {bold.blue default} ]  folder. Would you like to copy your key to [ {bold.blue testnet} ] folder? {bold.green (y/n)}}`,
                 false
             );
             if (answer) {
@@ -23,7 +23,7 @@ module.exports = async function checkCredentials(
                 await keyStore.setKey('testnet', accountId, defaultKeys);
             } else {
                 throw console.log(
-                    chalk`{bold.white Please relocate credentials found in [ default ] directory to [ testnet ] directory.}`
+                    chalk`{bold.white Please relocate credentials found in [ {bold.blue default} ] directory to [ {bold.blue testnet} ] directory using {bold.yellow near login}.}`
                 );
             }
         } else if (testnetKeys && networkId === 'default') {

--- a/utils/check-credentials.js
+++ b/utils/check-credentials.js
@@ -5,23 +5,28 @@ module.exports = async function checkCredentials(
     networkId,
     keyStore
 ) {
-    if(networkId != 'testnet' || networkId != 'default') return;
+    if(networkId !== 'testnet' || networkId !== 'default') return;
     if (!(await keyStore.getKey(networkId, accountId))) {
         console.log(
             `Unable to find [ ${networkId} ] credentials for [ ${accountId} ]`
         );
-        const defaultKeyPair = await keyStore.getKey('default', accountId);
-        if (defaultKeyPair) {
+        const testnetKeys = await keyStore.getKey('testnet', accountId);
+        const defaultKeys = await keyStore.getKey('default', accountId);
+        if (defaultKeys && networkId === 'testnet') {
             const answer = await askYesNoQuestion(
                 'Key found in deprecated [ default ] folder. Would you like to copy your key to [ testnet ] folder? (y/n): ',
                 false
             );
             if (answer) {
                 console.log('Copying key and retrying transaction...');
-                await keyStore.setKey('testnet', accountId, defaultKeyPair);
+                await keyStore.setKey('testnet', accountId);
             } else {
                 throw 'Please relocate credentials found in [ default ] directory to [ testnet ] directory.';
             }
-        } else throw 'error';
+        } else if (testnetKeys && networkId === 'default') {
+            console.log(
+                'Key found in [ testnet ] folder but your command is configured to use deprecated [ default ] network. Please upgrade near-cli or change your project\'s config file. '
+            );
+        }
     }
 };


### PR DESCRIPTION
Currently, there are two directories for `testnet` credentials.
  - `default`
  - `testnet`

This can be confusing as `create-near-app` and other example apps store access keys in `testnet` while `near-cli` stores access keys in `default`. Users report running into errors when trying to run `near-cli` commands with credentials in the wrong location. (see linked issue below)

This PR deprecates the `default` directory changing it to `testnet` and prompts users of this change. It also checks the `default` directory for the credentials (if not found in `testnet` ) and asks users if they would like us to copy their keys to the new location. This leaves two copies of an account's access keys to avoid breaking changes until we decide to permanently remove `default`.

Fixes https://github.com/near/near-cli/issues/677