### PR TITLE
Generate key for a given HD path improvements

### DIFF
--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -15,8 +15,9 @@ module.exports = {
             }
             console.log(`Please, confirm on the Ledger receiveng of the public key for HD path ${argv.useLedgerKey}`);
             const publicKey = await argv.signer.getPublicKey(false);
-            console.log("Please confirm that this key is the one that is displayed on the Ledger screen");
-            await argv.signer.getPublicKey(false, true);
+            if (!publicKey) return;
+            console.log("Please, confirm that this key is the one that is displayed on the Ledger screen now");
+            if (!await argv.signer.getPublicKey(false)) return;
             console.log(`Implicit account: ${implicitAccountId(publicKey.toString())}`);
             // TODO: query all accounts with this public key here.
             // TODO: check if implicit account exist, and if the key doen't match already.
@@ -41,7 +42,7 @@ module.exports = {
             const seededKeyPair = await argv.signer.keyStore.getKey(argv.networkId, argv.accountId);
             await keyStore.setKey(argv.networkId, argv.accountId, seededKeyPair);
         }
-            
+
         console.log(`Key pair with ${argv.publicKey} public key for an account "${argv.accountId}"`);
     })
 };

--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -7,7 +7,7 @@ module.exports = {
     desc: 'generate key or show key from Ledger',
     builder: (yargs) => yargs
         .option('yolo', {
-            description: 'Do not ask for extra confitmation when using Ledger',
+            description: 'Do not ask for extra confirmation when using Ledger',
             type: 'boolean',
         }),
     handler: exitOnError(async (argv) => {
@@ -17,7 +17,7 @@ module.exports = {
             if (argv.accountId) {
                 console.log('WARN: Account id is provided but ignored in case of using Ledger.');
             }
-            console.log(`Please, confirm on the Ledger receiveng of the public key for HD path ${argv.useLedgerKey}`);
+            console.log(`Please, confirm on the Ledger receiving the public key for HD path ${argv.useLedgerKey}`);
             const publicKey = await argv.signer.getPublicKey({ enableCaching: false });
             if (!publicKey) {
                 return;

--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -25,8 +25,8 @@ module.exports = {
             if (!argv.yolo) {
                 console.log('Please, confirm that this key is the one that is displayed on the Ledger screen now');
                 if (!await argv.signer.getPublicKey({ enableCaching: false })) {
-                    return
-                };
+                    return;
+                }
             }
             console.log(`Implicit account: ${implicitAccountId(publicKey.toString())}`);
             // TODO: query all accounts with this public key here.

--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -5,7 +5,11 @@ const implicitAccountId = require('../utils/implicit-accountid');
 module.exports = {
     command: 'generate-key [account-id]',
     desc: 'generate key or show key from Ledger',
-    builder: (yargs) => yargs,
+    builder: (yargs) => yargs
+        .option('yolo', {
+            description: 'Do not ask for extra confitmation when using Ledger',
+            type: 'boolean',
+        }),
     handler: exitOnError(async (argv) => {
         let near = await require('../utils/connect')(argv);
 
@@ -15,9 +19,15 @@ module.exports = {
             }
             console.log(`Please, confirm on the Ledger receiveng of the public key for HD path ${argv.useLedgerKey}`);
             const publicKey = await argv.signer.getPublicKey({ enableCaching: false });
-            if (!publicKey) return;
-            console.log('Please, confirm that this key is the one that is displayed on the Ledger screen now');
-            if (!await argv.signer.getPublicKey({ enableCaching: false })) return;
+            if (!publicKey) {
+                return;
+            }
+            if (!argv.yolo) {
+                console.log('Please, confirm that this key is the one that is displayed on the Ledger screen now');
+                if (!await argv.signer.getPublicKey({ enableCaching: false })) {
+                    return
+                };
+            }
             console.log(`Implicit account: ${implicitAccountId(publicKey.toString())}`);
             // TODO: query all accounts with this public key here.
             // TODO: check if implicit account exist, and if the key doen't match already.

--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -13,8 +13,10 @@ module.exports = {
             if (argv.accountId) {
                 console.log('WARN: Account id is provided but ignored in case of using Ledger.');
             }
-            const publicKey = await argv.signer.getPublicKey();
-            // NOTE: Command above already prints public key.
+            console.log(`Please, confirm on the Ledger receiveng of the public key for HD path ${argv.useLedgerKey}`);
+            const publicKey = await argv.signer.getPublicKey(false);
+            console.log("Please confirm that this key is the one that is displayed on the Ledger screen");
+            await argv.signer.getPublicKey(false, true);
             console.log(`Implicit account: ${implicitAccountId(publicKey.toString())}`);
             // TODO: query all accounts with this public key here.
             // TODO: check if implicit account exist, and if the key doen't match already.

--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -16,7 +16,7 @@ module.exports = {
             console.log(`Please, confirm on the Ledger receiveng of the public key for HD path ${argv.useLedgerKey}`);
             const publicKey = await argv.signer.getPublicKey(false);
             if (!publicKey) return;
-            console.log("Please, confirm that this key is the one that is displayed on the Ledger screen now");
+            console.log('Please, confirm that this key is the one that is displayed on the Ledger screen now');
             if (!await argv.signer.getPublicKey(false)) return;
             console.log(`Implicit account: ${implicitAccountId(publicKey.toString())}`);
             // TODO: query all accounts with this public key here.

--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -14,10 +14,10 @@ module.exports = {
                 console.log('WARN: Account id is provided but ignored in case of using Ledger.');
             }
             console.log(`Please, confirm on the Ledger receiveng of the public key for HD path ${argv.useLedgerKey}`);
-            const publicKey = await argv.signer.getPublicKey(false);
+            const publicKey = await argv.signer.getPublicKey({ enableCaching: false });
             if (!publicKey) return;
             console.log('Please, confirm that this key is the one that is displayed on the Ledger screen now');
-            if (!await argv.signer.getPublicKey(false)) return;
+            if (!await argv.signer.getPublicKey({ enableCaching: false })) return;
             console.log(`Implicit account: ${implicitAccountId(publicKey.toString())}`);
             // TODO: query all accounts with this public key here.
             // TODO: check if implicit account exist, and if the key doen't match already.

--- a/middleware/ledger.js
+++ b/middleware/ledger.js
@@ -16,35 +16,41 @@ module.exports = async function useLedgerSigner({ useLedgerKey: ledgerKeyPath, n
     const client = await createClient(transport);
 
     let cachedPublicKeys = {};
-    async function getPublicKeyForPath(hdKeyPath, enableCashing = true) {
+    async function getPublicKeyForPath({ hdKeyPath, enableCaching }) {
         // NOTE: Public key is cached to avoid confirming on Ledger multiple times
-        if (cachedPublicKeys[ledgerKeyPath] && enableCashing) {
+        if (cachedPublicKeys[ledgerKeyPath] && enableCaching) {
             return cachedPublicKeys[hdKeyPath];
         }
         console.log('Waiting for confirmation on Ledger...');
-        let rawPublicKey = '';
+        let rawPublicKey;
         try {
-            rawPublicKey = await client.getPublicKey(false, true);
+            rawPublicKey = await client.getPublicKey(hdKeyPath);
             console.log('Approved');
         } catch (e) {
             if (e.statusText === 'CONDITIONS_OF_USE_NOT_SATISFIED') {
                 console.log('Rejected from the Ledger ');
                 return;
             }
-            throw (e);
+            throw e;
         }
         const publicKey = new PublicKey({ keyType: KeyType.ED25519, data: rawPublicKey });
-        if (enableCashing) { cachedPublicKeys[hdKeyPath] = publicKey; }
+        if (enableCaching) { cachedPublicKeys[hdKeyPath] = publicKey; }
         console.log('Using public key:', publicKey.toString());
         return publicKey;
     }
 
     let signer = {
-        async getPublicKey(enableCashing = true) {
-            return getPublicKeyForPath(ledgerKeyPath, enableCashing);
+        async getPublicKey({ enableCaching }) {
+            return getPublicKeyForPath({
+                hdKeyPath: ledgerKeyPath,
+                enableCaching: enableCaching
+            });
         },
         async signMessage(message) {
-            const publicKey = await getPublicKeyForPath(ledgerKeyPath);
+            const publicKey = await getPublicKeyForPath({
+                hdKeyPath: ledgerKeyPath,
+                enableCaching: true
+            });
             console.log('Waiting for confirmation on Ledger...');
             const signature = await client.sign(message, ledgerKeyPath);
             return { signature, publicKey };
@@ -52,7 +58,10 @@ module.exports = async function useLedgerSigner({ useLedgerKey: ledgerKeyPath, n
     };
 
     if (newLedgerKey) {
-        publicKey = await getPublicKeyForPath(newLedgerKey);
+        publicKey = await getPublicKeyForPath({
+            hdKeyPath: newLedgerKey,
+            enableCaching: true
+        });
     }
 
     return { signer, publicKey, usingLedger: true };

--- a/middleware/ledger.js
+++ b/middleware/ledger.js
@@ -25,7 +25,7 @@ module.exports = async function useLedgerSigner({ useLedgerKey: ledgerKeyPath, n
         let rawPublicKey = '';
         try {
             rawPublicKey = await client.getPublicKey(false, true);
-            console.log("Approved");
+            console.log('Approved');
         } catch (e) {
             if (e.statusText === 'CONDITIONS_OF_USE_NOT_SATISFIED') {
                 console.log('Rejected from the Ledger ');

--- a/middleware/ledger.js
+++ b/middleware/ledger.js
@@ -34,7 +34,9 @@ module.exports = async function useLedgerSigner({ useLedgerKey: ledgerKeyPath, n
             throw e;
         }
         const publicKey = new PublicKey({ keyType: KeyType.ED25519, data: rawPublicKey });
-        if (enableCaching) { cachedPublicKeys[hdKeyPath] = publicKey; }
+        if (enableCaching) {
+            cachedPublicKeys[hdKeyPath] = publicKey;
+        }
         console.log('Using public key:', publicKey.toString());
         return publicKey;
     }

--- a/middleware/ledger.js
+++ b/middleware/ledger.js
@@ -22,7 +22,17 @@ module.exports = async function useLedgerSigner({ useLedgerKey: ledgerKeyPath, n
             return cachedPublicKeys[hdKeyPath];
         }
         console.log('Waiting for confirmation on Ledger...');
-        const rawPublicKey = await client.getPublicKey(hdKeyPath);
+        let rawPublicKey = '';
+        try {
+            rawPublicKey = await client.getPublicKey(false, true);
+            console.log("Approved");
+        } catch (e) {
+            if (e.statusText === 'CONDITIONS_OF_USE_NOT_SATISFIED') {
+                console.log('Rejected from the Ledger ');
+                return;
+            }
+            throw (e);
+        }
         const publicKey = new PublicKey({ keyType: KeyType.ED25519, data: rawPublicKey });
         if (enableCashing) { cachedPublicKeys[hdKeyPath] = publicKey; }
         console.log('Using public key:', publicKey.toString());


### PR DESCRIPTION
Details in: https://github.com/near/near-cli/issues/567

Example:
`serhii@yoga ~/P/N/near-cli (generate-key)> ./bin/near generate-key --useLedgerKey="44'/397'/0'/0'/2'"`
`Make sure to connect your Ledger and open NEAR app`
`Please, confirm on the Ledger receiveng of the public key for HD path 44'/397'/0'/0'/2'`
`Waiting for confirmation on Ledger...`
`Approved`
`Using public key: ed25519:8dxydfuh9NphxaJfavBNPaTJZZkAroRPopbBh7JNzdky`
`Please, confirm that this key is the one that is displayed on the Ledger screen now`
`Waiting for confirmation on Ledger...`
`Approved`
`Using public key: ed25519:8dxydfuh9NphxaJfavBNPaTJZZkAroRPopbBh7JNzdky`
`Implicit account: 717a02a63b986a5ea6fccd8f191ff5087f29809e242e6b3f3fad9f4c03720b5e`