### PR TITLE
`amount` option renamed to `deposit` (with alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ near dev-deploy out/main.wasm
 **Note:** Contract calls require a transaction fee (gas) so you will need an access key for the `--accountId` that will be charged. ([`near login`](http://docs.near.org/docs/tools/near-cli#near-login))
 
 -   arguments: `contractName` `method_name` `{ args }` `--accountId`
--   options: `--gas` `--amount`
+-   options: `--gas` `--deposit`
 
 **Example:**
 
@@ -741,14 +741,14 @@ near evm-view evm 0x89dfB1Cd61F05ad3971EC1f83056Fd9793c2D521 getAdopters '[]' --
 
 ---
 
-### `near evm-call`
+### `near evm-call (deprecated)`
 
 > makes an EVM contract call which can modify _or_ view state.
 
 **Note:** Contract calls require a transaction fee (gas) so you will need an access key for the `--accountId` that will be charged. ([`near login`](http://docs.near.org/docs/tools/near-cli#near-login))
 
 -   arguments: `evmAccount` `contractName` `methodName` `[arguments]` `--abi` `--accountId`
--   options: `default` (`--gas` and `--amount` coming soon…)
+-   options: `default` (`--gas` and `--deposit` coming soon…)
 
 **Example:**
 
@@ -1240,24 +1240,23 @@ With NEAR REPL you have complete access to [`near-api-js`](https://github.com/ne
 
 ## Options
 
-| Option                        | Description                                                                                                                            |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `--help`                      | shows help _(can be used alone or on any command)_                                                                                     |
-| `--version`                   | shows installed version of `near-cli`                                                                                                  |
-| `--nodeUrl`, `--node_url`     | selects an [RPC URL](http://docs.near.org/docs/develop/front-end/rpc) _(`testnet`, `mainnet`, `betanet`)_                              |
-| `--helperUrl`                 | points to a [contract helper](https://github.com/near/near-contract-helper) instance you want to use for account creation / management |
-| `--keyPath`                   | specify a path to `--masterAccount` key                                                                                                |
-| `--accountId`, `--account_id` | selects an account ID                                                                                                                  |
-| `--useLedgerKey`              | uses Ledger with given HD key path `[default: "44'/397'/0'/0'/1'"]`                                                                    |
-| `--seedPhrase`                | uses a mnemonic seed phrase                                                                                                            |
-| `--seedPath`                  | specify a HD path derivation `[default: "m/44'/397'/0'"]`                                                                              |
-| `--walletUrl`                 | selects a [NEAR wallet](http://wallet.testnet.near.org) URL                                                                            |
-| `--contractName`              | selects an account contract name                                                                                                       |
-| `--masterAccount`             | selects a master account                                                                                                               |
-| `--helperAccount`             | selects an expected top-level account for a network                                                                                    |
-| `--verbose`, `-v`             | shows verbose output                                                                                                                   |
-| `--gas`                       | specifies amount of gas to use for a contract call `[default: "100000000000000"]`                                                      |
-| `--amount`                    | Number of NEAR tokens (Ⓝ) to attach `[default: "0"]`                                                                                   |
+| Option                     | Description                                                                                                                            |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `--help`                   |  Show help  [boolean]                                                                                                                  |
+| `--version`                |  Show version number  [boolean]                                                                                                        | 
+| `--nodeUrl, --node_url`    |  NEAR node URL  [string] [default: "https://rpc.testnet.near.org"]                                                                     |
+| `--networkId, --network_id`|  NEAR network ID, allows using different keys based on network  [string] [default: "testnet"]                                          |
+| `--helperUrl`              |  NEAR contract helper URL  [string]                                                                                                    |
+| `--keyPath`                |  Path to master account key  [string]                                                                                                  |
+| `--accountId, --account_id`|  Unique identifier for the account  [string]                                                                                           |
+| `--useLedgerKey`           |  Use Ledger for signing with given HD key path  [string] [default: "44'/397'/0'/0'/1'"]                                                |
+| `--seedPhrase`             |  Seed phrase mnemonic  [string]                                                                                                        |
+| `--seedPath`               |  HD path derivation  [string] [default: "m/44'/397'/0'"]                                                                               |
+| `--walletUrl`              |  Website for NEAR Wallet  [string]                                                                                                     |
+| `--contractName`           |  Account name of contract  [string]                                                                                                    |
+| `--masterAccount`          |  Master account used when creating new accounts  [string]                                                                              |
+| `--helperAccount`          |  Expected top-level account for a network  [string]                                                                                    |
+| `-v, --verbose`            |  Prints out verbose output  [boolean] [default: false]                                                                                 |
 
 > Got a question? <a href="https://stackoverflow.com/questions/tagged/nearprotocol"> <h8>Ask it on StackOverflow!</h8></a>
 

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -257,7 +257,6 @@ yargs // eslint-disable-line
         'wasmFile': 'wasm_file',
         'projectDir': 'project_dir',
         'outDir': 'out_dir',
-        'deposit': 'amount'
     })
     .showHelpOnFail(true)
     .recommendCommands()

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -256,7 +256,8 @@ yargs // eslint-disable-line
         'networkId': ['network_id'],
         'wasmFile': 'wasm_file',
         'projectDir': 'project_dir',
-        'outDir': 'out_dir'
+        'outDir': 'out_dir',
+        'deposit': 'amount'
     })
     .showHelpOnFail(true)
     .recommendCommands()

--- a/commands/call.js
+++ b/commands/call.js
@@ -14,7 +14,7 @@ module.exports = {
             default: '100000000000000'
         })
         .option('deposit', {
-            desc: 'Number of tokens to attach (in NEAR) in a function call',
+            desc: 'Number of tokens to attach (in NEAR) to a function call',
             type: 'string',
             default: '0',
             alias: 'amount'

--- a/commands/call.js
+++ b/commands/call.js
@@ -16,7 +16,8 @@ module.exports = {
         .option('deposit', {
             desc: 'Number of tokens to attach (in NEAR) in a function call',
             type: 'string',
-            default: '0'
+            default: '0',
+            alias: 'amount'
         })
         .option('base64',  {
             desc: 'Treat arguments as base64-encoded BLOB.',

--- a/commands/call.js
+++ b/commands/call.js
@@ -13,8 +13,8 @@ module.exports = {
             type: 'string',
             default: '100000000000000'
         })
-        .option('amount', {
-            desc: 'Number of tokens to attach (in NEAR)',
+        .option('deposit', {
+            desc: 'Number of tokens to attach (in NEAR) in a function call',
             type: 'string',
             default: '0'
         })
@@ -39,7 +39,7 @@ module.exports = {
 async function scheduleFunctionCall(options) {
     await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
-        (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
+        (options.deposit && options.deposit != '0' ? ` with attached ${options.deposit} NEAR` : ''));
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const parsedArgs = options.base64 ? Buffer.from(options.args, 'base64') : JSON.parse(options.args || '{}');
@@ -48,7 +48,7 @@ async function scheduleFunctionCall(options) {
         options.methodName,
         parsedArgs,
         options.gas,
-        utils.format.parseNearAmount(options.amount));
+        utils.format.parseNearAmount(options.deposit));
     const result = providers.getTransactionLastResult(functionCallResponse);
     inspectResponse.prettyPrintResponse(functionCallResponse, options);
     console.log(inspectResponse.formatResponse(result));

--- a/commands/evm-call.js
+++ b/commands/evm-call.js
@@ -9,7 +9,7 @@ module.exports = {
             type: 'string',
             default: '100000000000000'
         })
-        .option('amount', {
+        .option('deposit', {
             desc: 'Number of tokens to attach',
             type: 'string',
             default: '0'

--- a/commands/evm-call.js
+++ b/commands/evm-call.js
@@ -12,7 +12,8 @@ module.exports = {
         .option('deposit', {
             desc: 'Number of tokens to attach',
             type: 'string',
-            default: '0'
+            default: '0',
+            alias: 'amount',
         })
         .option('args', {
             desc: 'Arguments to the contract call, in JSON format (e.g. \'[1, "str"]\') based on contract ABI',


### PR DESCRIPTION
I think that `deposit` is a better word for a deposit :)

Options list was out of date in README

off top:  probably we should delete dead EVM commands in the next release, so basically we can do that in the next PR