### PR TITLE
update near call to use object args

### DIFF
--- a/commands/call.js
+++ b/commands/call.js
@@ -11,28 +11,28 @@ module.exports = {
         .option('gas', {
             desc: 'Max amount of gas this call can use (in gas units)',
             type: 'string',
-            default: '100000000000000',
+            default: '100000000000000'
         })
         .option('deposit', {
             desc: 'Number of tokens to attach (in NEAR) to a function call',
             type: 'string',
             default: '0',
-            alias: 'amount',
+            alias: 'amount'
         })
         .option('base64', {
             desc: 'Treat arguments as base64-encoded BLOB.',
             type: 'boolean',
-            default: false,
+            default: false
         })
         .option('args', {
             desc: 'Arguments to the contract call, in JSON format by default (e.g. \'{"param_a": "value"}\')',
             type: 'string',
-            default: null,
+            default: null
         })
         .option('accountId', {
             required: true,
             desc: 'Unique identifier for the account that will be used to sign this call',
-            type: 'string',
+            type: 'string'
         }),
     handler: exitOnError(scheduleFunctionCall)
 };
@@ -40,7 +40,7 @@ module.exports = {
 async function scheduleFunctionCall(options) {
     await checkCredentials(options.accountId, options.networkId, options.keyStore);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
-            (options.deposit && options.deposit != '0' ? ` with attached ${options.deposit} NEAR` : ''));
+        (options.deposit && options.deposit != '0' ? ` with attached ${options.deposit} NEAR` : ''));
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const parsedArgs = options.base64 ? Buffer.from(options.args, 'base64') : JSON.parse(options.args || '{}');

--- a/commands/call.js
+++ b/commands/call.js
@@ -7,56 +7,43 @@ const checkCredentials = require('../utils/check-credentials');
 module.exports = {
     command: 'call <contractName> <methodName> [args]',
     desc: 'schedule smart contract call which can modify state',
-    builder: (yargs) =>
-        yargs
-            .option('gas', {
-                desc: 'Max amount of gas this call can use (in gas units)',
-                type: 'string',
-                default: '100000000000000',
-            })
-            .option('deposit', {
-                desc: 'Number of tokens to attach (in NEAR) to a function call',
-                type: 'string',
-                default: '0',
-                alias: 'amount',
-            })
-            .option('base64', {
-                desc: 'Treat arguments as base64-encoded BLOB.',
-                type: 'boolean',
-                default: false,
-            })
-            .option('args', {
-                desc: 'Arguments to the contract call, in JSON format by default (e.g. \'{"param_a": "value"}\')',
-                type: 'string',
-                default: null,
-            })
-            .option('accountId', {
-                required: true,
-                desc: 'Unique identifier for the account that will be used to sign this call',
-                type: 'string',
-            }),
-    handler: exitOnError(scheduleFunctionCall),
+    builder: (yargs) => yargs
+        .option('gas', {
+            desc: 'Max amount of gas this call can use (in gas units)',
+            type: 'string',
+            default: '100000000000000',
+        })
+        .option('deposit', {
+            desc: 'Number of tokens to attach (in NEAR) to a function call',
+            type: 'string',
+            default: '0',
+            alias: 'amount',
+        })
+        .option('base64', {
+            desc: 'Treat arguments as base64-encoded BLOB.',
+            type: 'boolean',
+            default: false,
+        })
+        .option('args', {
+            desc: 'Arguments to the contract call, in JSON format by default (e.g. \'{"param_a": "value"}\')',
+            type: 'string',
+            default: null,
+        })
+        .option('accountId', {
+            required: true,
+            desc: 'Unique identifier for the account that will be used to sign this call',
+            type: 'string',
+        }),
+    handler: exitOnError(scheduleFunctionCall)
 };
 
 async function scheduleFunctionCall(options) {
-    await checkCredentials(
-        options.accountId,
-        options.networkId,
-        options.keyStore
-    );
-    console.log(
-        `Scheduling a call: ${options.contractName}.${options.methodName}(${
-            options.args || ''
-        })` +
-            (options.deposit && options.deposit != '0'
-                ? ` with attached ${options.deposit} NEAR`
-                : '')
-    );
+    await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
+            (options.deposit && options.deposit != '0' ? ` with attached ${options.deposit} NEAR` : ''));
     const near = await connect(options);
     const account = await near.account(options.accountId);
-    const parsedArgs = options.base64
-        ? Buffer.from(options.args, 'base64')
-        : JSON.parse(options.args || '{}');
+    const parsedArgs = options.base64 ? Buffer.from(options.args, 'base64') : JSON.parse(options.args || '{}');
     const functionCallResponse = await account.functionCall({
         contractId: options.contractName,
         methodName: options.methodName,

--- a/commands/call.js
+++ b/commands/call.js
@@ -1,39 +1,39 @@
-const { providers, utils } = require("near-api-js");
-const exitOnError = require("../utils/exit-on-error");
-const connect = require("../utils/connect");
-const inspectResponse = require("../utils/inspect-response");
-const checkCredentials = require("../utils/check-credentials");
+const { providers, utils } = require('near-api-js');
+const exitOnError = require('../utils/exit-on-error');
+const connect = require('../utils/connect');
+const inspectResponse = require('../utils/inspect-response');
+const checkCredentials = require('../utils/check-credentials');
 
 module.exports = {
-    command: "call <contractName> <methodName> [args]",
-    desc: "schedule smart contract call which can modify state",
+    command: 'call <contractName> <methodName> [args]',
+    desc: 'schedule smart contract call which can modify state',
     builder: (yargs) =>
         yargs
-            .option("gas", {
-                desc: "Max amount of gas this call can use (in gas units)",
-                type: "string",
-                default: "100000000000000",
+            .option('gas', {
+                desc: 'Max amount of gas this call can use (in gas units)',
+                type: 'string',
+                default: '100000000000000',
             })
-            .option("deposit", {
-                desc: "Number of tokens to attach (in NEAR) to a function call",
-                type: "string",
-                default: "0",
-                alias: "amount",
+            .option('deposit', {
+                desc: 'Number of tokens to attach (in NEAR) to a function call',
+                type: 'string',
+                default: '0',
+                alias: 'amount',
             })
-            .option("base64", {
-                desc: "Treat arguments as base64-encoded BLOB.",
-                type: "boolean",
+            .option('base64', {
+                desc: 'Treat arguments as base64-encoded BLOB.',
+                type: 'boolean',
                 default: false,
             })
-            .option("args", {
+            .option('args', {
                 desc: 'Arguments to the contract call, in JSON format by default (e.g. \'{"param_a": "value"}\')',
-                type: "string",
+                type: 'string',
                 default: null,
             })
-            .option("accountId", {
+            .option('accountId', {
                 required: true,
-                desc: "Unique identifier for the account that will be used to sign this call",
-                type: "string",
+                desc: 'Unique identifier for the account that will be used to sign this call',
+                type: 'string',
             }),
     handler: exitOnError(scheduleFunctionCall),
 };
@@ -46,17 +46,17 @@ async function scheduleFunctionCall(options) {
     );
     console.log(
         `Scheduling a call: ${options.contractName}.${options.methodName}(${
-            options.args || ""
+            options.args || ''
         })` +
-            (options.deposit && options.deposit != "0"
+            (options.deposit && options.deposit != '0'
                 ? ` with attached ${options.deposit} NEAR`
-                : "")
+                : '')
     );
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const parsedArgs = options.base64
-        ? Buffer.from(options.args, "base64")
-        : JSON.parse(options.args || "{}");
+        ? Buffer.from(options.args, 'base64')
+        : JSON.parse(options.args || '{}');
     const functionCallResponse = await account.functionCall({
         contractId: options.contractName,
         methodName: options.methodName,

--- a/commands/call.js
+++ b/commands/call.js
@@ -1,55 +1,69 @@
-const { providers, utils } = require('near-api-js');
-const exitOnError = require('../utils/exit-on-error');
-const connect = require('../utils/connect');
-const inspectResponse = require('../utils/inspect-response');
-const checkCredentials = require('../utils/check-credentials');
+const { providers, utils } = require("near-api-js");
+const exitOnError = require("../utils/exit-on-error");
+const connect = require("../utils/connect");
+const inspectResponse = require("../utils/inspect-response");
+const checkCredentials = require("../utils/check-credentials");
 
 module.exports = {
-    command: 'call <contractName> <methodName> [args]',
-    desc: 'schedule smart contract call which can modify state',
-    builder: (yargs) => yargs
-        .option('gas', {
-            desc: 'Max amount of gas this call can use (in gas units)',
-            type: 'string',
-            default: '100000000000000'
-        })
-        .option('deposit', {
-            desc: 'Number of tokens to attach (in NEAR) to a function call',
-            type: 'string',
-            default: '0',
-            alias: 'amount'
-        })
-        .option('base64',  {
-            desc: 'Treat arguments as base64-encoded BLOB.',
-            type: 'boolean',
-            default: false
-        })
-        .option('args', {
-            desc: 'Arguments to the contract call, in JSON format by default (e.g. \'{"param_a": "value"}\')',
-            type: 'string',
-            default: null
-        })
-        .option('accountId', {
-            required: true,
-            desc: 'Unique identifier for the account that will be used to sign this call',
-            type: 'string',
-        }),
-    handler: exitOnError(scheduleFunctionCall)
+    command: "call <contractName> <methodName> [args]",
+    desc: "schedule smart contract call which can modify state",
+    builder: (yargs) =>
+        yargs
+            .option("gas", {
+                desc: "Max amount of gas this call can use (in gas units)",
+                type: "string",
+                default: "100000000000000",
+            })
+            .option("deposit", {
+                desc: "Number of tokens to attach (in NEAR) to a function call",
+                type: "string",
+                default: "0",
+                alias: "amount",
+            })
+            .option("base64", {
+                desc: "Treat arguments as base64-encoded BLOB.",
+                type: "boolean",
+                default: false,
+            })
+            .option("args", {
+                desc: 'Arguments to the contract call, in JSON format by default (e.g. \'{"param_a": "value"}\')',
+                type: "string",
+                default: null,
+            })
+            .option("accountId", {
+                required: true,
+                desc: "Unique identifier for the account that will be used to sign this call",
+                type: "string",
+            }),
+    handler: exitOnError(scheduleFunctionCall),
 };
 
 async function scheduleFunctionCall(options) {
-    await checkCredentials(options.accountId, options.networkId, options.keyStore);
-    console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
-        (options.deposit && options.deposit != '0' ? ` with attached ${options.deposit} NEAR` : ''));
+    await checkCredentials(
+        options.accountId,
+        options.networkId,
+        options.keyStore
+    );
+    console.log(
+        `Scheduling a call: ${options.contractName}.${options.methodName}(${
+            options.args || ""
+        })` +
+            (options.deposit && options.deposit != "0"
+                ? ` with attached ${options.deposit} NEAR`
+                : "")
+    );
     const near = await connect(options);
     const account = await near.account(options.accountId);
-    const parsedArgs = options.base64 ? Buffer.from(options.args, 'base64') : JSON.parse(options.args || '{}');
-    const functionCallResponse = await account.functionCall(
-        options.contractName,
-        options.methodName,
-        parsedArgs,
-        options.gas,
-        utils.format.parseNearAmount(options.deposit));
+    const parsedArgs = options.base64
+        ? Buffer.from(options.args, "base64")
+        : JSON.parse(options.args || "{}");
+    const functionCallResponse = await account.functionCall({
+        contractId: options.contractName,
+        methodName: options.methodName,
+        args: parsedArgs,
+        gas: options.gas,
+        attachedDeposit: utils.format.parseNearAmount(options.deposit),
+    });
     const result = providers.getTransactionLastResult(functionCallResponse);
     inspectResponse.prettyPrintResponse(functionCallResponse, options);
     console.log(inspectResponse.formatResponse(result));


### PR DESCRIPTION
In `near-api-js`, calling `account.functionCall` using positional args is being deprecated. This PR updates this command to use the newer function call method of passing arguments as an object.

Fixes #781 