### PR TITLE
updated signAndSendTranscation to use object args

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,10 @@ exports.deploy = async function (options) {
         );
     }
 
-    const result = await account.signAndSendTransaction(options.accountId, txs);
+    const result = await account.signAndSendTransaction({
+        receiverId:options.accountId, 
+        actions:txs
+    });
     inspectResponse.prettyPrintResponse(result, options);
     let state = await account.state();
     let codeHash = state.code_hash;

--- a/index.js
+++ b/index.js
@@ -57,8 +57,8 @@ exports.deploy = async function (options) {
     }
 
     const result = await account.signAndSendTransaction({
-        receiverId:options.accountId, 
-        actions:txs
+        receiverId: options.accountId, 
+        actions: txs
     });
     inspectResponse.prettyPrintResponse(result, options);
     let state = await account.state();


### PR DESCRIPTION
Issue No - #760 
Desc: We were using `signAndSendTranscation` as positional args which is deprecated in `near-api-js`  . This PR updates this command to use the newer function call method of passing arguments as an object.