### PR TITLE
formatted near state command

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,8 +186,18 @@ exports.viewAccount = async function (options) {
     if (state && state.amount) {
         state['formattedAmount'] = utils.format.formatNearAmount(state.amount);
     }
-    console.log(`Account ${options.accountId}`);
-    console.log(inspectResponse.formatResponse(state));
+    const storageInM=state.storage_usage/1e+6;
+    const accountDetails={
+        "Account:":`${options.accountId} at block ${state.block_height} (https://explorer.testnet.near.org/blocks/${state.block_hash})`,
+        [chalk.bold("amount:")]:`${state.amount} ${chalk.bold("yn")}`,
+        "locked:":state.locked,
+        "storage:":`${storageInM}M (${state.storage_usage} bytes)`,
+        "code_hash:":`'${state.code_hash}'`
+    };
+    for(const property in accountDetails){
+        console.log(property,accountDetails[property]);
+    }
+    console.log(`\nFor more details see https://explorer.testnet.near.org/accounts/${options.accountId}`)
 };
 
 exports.deleteAccount = async function (options) {

--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ exports.viewAccount = async function (options) {
         [chalk.bold('Account:')]:`${options.accountId} at block ${state.block_height}`,
         [chalk.bold('Amount:')]:`~${amount} ${chalk.bold('yn')}`,
         [chalk.bold('Raw Amount:')]:`${state.amount} ${chalk.bold('yn')}`,
-        [chalk.bold('Locked:')]:state.locked,
+        [chalk.bold('Locked:')]:`${state.locked} yn`,
         [chalk.bold('Storage:')]:`${storage}`,
         [chalk.bold('Storage paid at:')]:`${state.storage_paid_at}`,
         [chalk.bold('Code hash:')]:`'${state.code_hash}'`

--- a/index.js
+++ b/index.js
@@ -188,16 +188,16 @@ exports.viewAccount = async function (options) {
     }
     const storageInM=state.storage_usage/1e+6;
     const accountDetails={
-        "Account:":`${options.accountId} at block ${state.block_height} (https://explorer.testnet.near.org/blocks/${state.block_hash})`,
-        [chalk.bold("amount:")]:`${state.amount} ${chalk.bold("yn")}`,
-        "locked:":state.locked,
-        "storage:":`${storageInM}M (${state.storage_usage} bytes)`,
-        "code_hash:":`'${state.code_hash}'`
+        'Account:':`${options.accountId} at block ${state.block_height} (https://explorer.testnet.near.org/blocks/${state.block_hash})`,
+        [chalk.bold('amount:')]:`${state.amount} ${chalk.bold('yn')}`,
+        'locked:':state.locked,
+        'storage:':`${storageInM}M (${state.storage_usage} bytes)`,
+        'code_hash:':`'${state.code_hash}'`
     };
     for(const property in accountDetails){
         console.log(property,accountDetails[property]);
     }
-    console.log(`\nFor more details see https://explorer.testnet.near.org/accounts/${options.accountId}`)
+    console.log(`\nFor more details see https://explorer.testnet.near.org/accounts/${options.accountId}`);
 };
 
 exports.deleteAccount = async function (options) {

--- a/index.js
+++ b/index.js
@@ -187,12 +187,16 @@ exports.viewAccount = async function (options) {
         state['formattedAmount'] = utils.format.formatNearAmount(state.amount);
     }
     const storageInM=state.storage_usage/1e+6;
+    const storage=storageInM<1?`${storageInM*1000} Kb `:`${storageInM} Mb`;
+    const amount=parseFloat(utils.format.formatNearAmount(`${state.amount}`)).toFixed(1);
     const accountDetails={
-        'Account:':`${options.accountId} at block ${state.block_height} (https://explorer.testnet.near.org/blocks/${state.block_hash})`,
-        [chalk.bold('amount:')]:`${state.amount} ${chalk.bold('yn')}`,
-        'locked:':state.locked,
-        'storage:':`${storageInM}M (${state.storage_usage} bytes)`,
-        'code_hash:':`'${state.code_hash}'`
+        [chalk.bold('Account:')]:`${options.accountId} at block ${state.block_height}`,
+        [chalk.bold('Amount:')]:`~${amount} ${chalk.bold('yn')}`,
+        [chalk.bold('Raw Amount:')]:`${state.amount} ${chalk.bold('yn')}`,
+        [chalk.bold('Locked:')]:state.locked,
+        [chalk.bold('Storage:')]:`${storage}`,
+        [chalk.bold('Storage paid at:')]:`${state.storage_paid_at}`,
+        [chalk.bold('Code hash:')]:`'${state.code_hash}'`
     };
     for(const property in accountDetails){
         console.log(property,accountDetails[property]);

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const { KeyPair, utils, transactions } = require('near-api-js');
 const connect = require('./utils/connect');
 const verify = require('./utils/verify-account');
 const capture = require('./utils/capture-login-success');
+const formatBytes = require('./utils/formatBytes-to-KB-GB');
 
 const inspectResponse = require('./utils/inspect-response');
 const eventtracking = require('./utils/eventtracking');
@@ -186,8 +187,7 @@ exports.viewAccount = async function (options) {
     if (state && state.amount) {
         state['formattedAmount'] = utils.format.formatNearAmount(state.amount);
     }
-    const storageInM=state.storage_usage/1e+6;
-    const storage=storageInM<1?`${storageInM*1000} Kb `:`${storageInM} Mb`;
+    const storage=formatBytes(state.storage_usage);
     const amount=parseFloat(utils.format.formatNearAmount(`${state.amount}`)).toFixed(1);
     const accountDetails={
         [chalk.bold('Account:')]:`${options.accountId} at block ${state.block_height}`,

--- a/utils/formatBytes-to-KB-GB.js
+++ b/utils/formatBytes-to-KB-GB.js
@@ -1,0 +1,11 @@
+const formatBytes = (bytes, decimals = 2) => {
+    if (bytes === 0) {
+        return "0 Bytes";
+    }
+    const k = 1024;
+    const dm = decimals < 0 ? 0 : decimals;
+    const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
+};
+module.exports= formatBytes;


### PR DESCRIPTION
Issue solved : #647 
Description: near state output ,
Before:
```
Account catisblack.testnet
{
  amount: '199992851312967202700000000',
  locked: '0',
  code_hash: '7H96nK1NFTYUUgiRxNER5AjRfUeD4W1TVNC6eKfSgzrf',
  storage_usage: 32597,
  storage_paid_at: 0,
  block_height: 51680778,
  block_hash: '8a94U8JyYd6XX6BDB8oEBHJuorh9xGfoyReJpEE6k9Ju',
  formattedAmount: '199.9928513129672027'
}

```
Now:
```
Account: catisblack.testnet at block 51680823 (https://explorer.testnet.near.org/blocks/TgTTWajwvDYtXr8wJevSg7Lsy33Awe3NjWLfF6dND7v)
**amount:** 199992851312967202700000000 **yn**
locked: 0
storage: 0.032597M (32597 bytes)
code_hash: '7H96nK1NFTYUUgiRxNER5AjRfUeD4W1TVNC6eKfSgzrf'

For more details see https://explorer.testnet.near.org/accounts/catisblack.testnet
```
_`amount` and `yn` are bold actually. It's not showing here in preview._