### PR TITLE
view state as base64 to be same as json rpc response

### DIFF
--- a/commands/view-state.js
+++ b/commands/view-state.js
@@ -40,6 +40,8 @@ async function viewState(options) {
     let state = await account.viewState(prefix, { blockId, finality });
     if (utf8) {
         state = state.map(({ key, value}) => ({ key: key.toString('utf-8'), value: value.toString('utf-8') }));
+    } else {
+        state = state.map(({ key, value}) => ({ key: key.toString('base64'), value: value.toString('base64') }));
     }
     console.log(formatResponse(state, options));
 }


### PR DESCRIPTION
Fix #788
Result:
```
near-cli (fix-view-state-format) bin/near view-state simple-state.abcdef.testnet --finality final
[
  {
    key: 'U1RBVEU=',
    value: 'AQAAAA4AAABhYmNkZWYudGVzdG5ldAUAAABoZWxsbw=='
  }
]
near-cli (fix-view-state-format) bin/near view-state simple-state.abcdef.testnet --finality final --utf8
[
  {
    key: 'STATE',
    value: '\x01\x00\x00\x00\x0E\x00\x00\x00abcdef.testnet\x05\x00\x00\x00hello'
  }
]
```