### PR TITLE
fix view-state finality flag

### DIFF
--- a/commands/view-state.js
+++ b/commands/view-state.js
@@ -22,7 +22,7 @@ module.exports = {
                 '`final` is for a block that has been validated on at least 66% of the nodes in the network',
             type: 'string',
             choices: ['optimistic', 'final'],
-            
+            default: 'final',
         })
         .option('utf8', {
             desc: 'Decode keys and values as UTF-8 strings',

--- a/commands/view-state.js
+++ b/commands/view-state.js
@@ -14,15 +14,13 @@ module.exports = {
         .option('block-id', {
             desc: 'The block number OR the block hash (base58-encoded).',
             type: 'string',
-            
-        })
-        .coerce({
-            blockId: (blockId) => {
+            coerce: (blockId) => {
                 if (blockId && !isNaN(blockId)) {
                     return Number(blockId);
                 }
                 return blockId;
             }
+            
         })
         .option('finality', {
             desc: '`optimistic` uses the latest block recorded on the node that responded to your query,\n' + 

--- a/commands/view-state.js
+++ b/commands/view-state.js
@@ -36,10 +36,10 @@ async function viewState(options) {
     const near = await connect(options);
     const account = await near.account(accountId);
     if (finality && blockId) {
-        console.error("Only one of --finality and --blockId can be provided");
+        console.error('Only one of --finality and --blockId can be provided');
         process.exit(1);
     } else if (!finality && !blockId) {
-        console.error("Must provide either --finality or --blockId");
+        console.error('Must provide either --finality or --blockId');
         process.exit(1);
     }
     // near-api-js takes block_id instead of blockId

--- a/commands/view-state.js
+++ b/commands/view-state.js
@@ -1,7 +1,6 @@
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const { formatResponse } = require('../utils/inspect-response');
-const yargs = require('yargs');
 
 module.exports = {
     command: 'view-state <account-id> [prefix]',
@@ -29,7 +28,7 @@ module.exports = {
             default: false
         })
         .conflicts('block-id', 'finality')
-        .check((argv, _) => {
+        .check((argv) => {
             if (!argv.finality && !argv.blockId) {
                 throw new Error('Must provide either --finality or --blockId');
             }

--- a/commands/view-state.js
+++ b/commands/view-state.js
@@ -22,7 +22,6 @@ module.exports = {
                 '`final` is for a block that has been validated on at least 66% of the nodes in the network',
             type: 'string',
             choices: ['optimistic', 'final'],
-            default: 'final',
         })
         .option('utf8', {
             desc: 'Decode keys and values as UTF-8 strings',
@@ -36,8 +35,21 @@ async function viewState(options) {
     const { accountId, prefix, finality, blockId, utf8 } = options;
     const near = await connect(options);
     const account = await near.account(accountId);
-
-    let state = await account.viewState(prefix, { blockId, finality });
+    if (finality && blockId) {
+        console.error("Only one of --finality and --blockId can be provided");
+        process.exit(1);
+    } else if (!finality && !blockId) {
+        console.error("Must provide either --finality or --blockId");
+        process.exit(1);
+    }
+    // near-api-js takes block_id instead of blockId
+    let block_id = blockId;
+    if (blockId && !isNaN(Number(blockId))) {
+        // If block id is a number (still string as command line args), it must be convert to JavaScript Number
+        // for near-api-js.
+        block_id = Number(blockId);
+    }
+    let state = await account.viewState(prefix, { block_id, finality });
     if (utf8) {
         state = state.map(({ key, value}) => ({ key: key.toString('utf-8'), value: value.toString('utf-8') }));
     }

--- a/commands/view-state.js
+++ b/commands/view-state.js
@@ -16,6 +16,14 @@ module.exports = {
             type: 'string',
             
         })
+        .coerce({
+            blockId: (blockId) => {
+                if (blockId && !isNaN(blockId)) {
+                    return Number(blockId);
+                }
+                return blockId;
+            }
+        })
         .option('finality', {
             desc: '`optimistic` uses the latest block recorded on the node that responded to your query,\n' + 
                 '`final` is for a block that has been validated on at least 66% of the nodes in the network',
@@ -33,14 +41,6 @@ module.exports = {
                 throw new Error('Must provide either --finality or --blockId');
             }
             return true;
-        })
-        .coerce({
-            blockId: (blockId) => {
-                if (blockId && !isNaN(blockId)) {
-                    return Number(blockId);
-                }
-                return blockId;
-            }
         }),
     handler: exitOnError(viewState)
 };

--- a/commands/view-state.js
+++ b/commands/view-state.js
@@ -1,6 +1,7 @@
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const { formatResponse } = require('../utils/inspect-response');
+const yargs = require('yargs');
 
 module.exports = {
     command: 'view-state <account-id> [prefix]',
@@ -10,7 +11,6 @@ module.exports = {
             desc: 'Return keys only with given prefix.',
             type: 'string',
             default: ''
-            
         })
         .option('block-id', {
             desc: 'The block number OR the block hash (base58-encoded).',
@@ -27,6 +27,21 @@ module.exports = {
             desc: 'Decode keys and values as UTF-8 strings',
             type: 'boolean',
             default: false
+        })
+        .conflicts('block-id', 'finality')
+        .check((argv, _) => {
+            if (!argv.finality && !argv.blockId) {
+                throw new Error('Must provide either --finality or --blockId');
+            }
+            return true;
+        })
+        .coerce({
+            blockId: (blockId) => {
+                if (blockId && !isNaN(blockId)) {
+                    return Number(blockId);
+                }
+                return blockId;
+            }
         }),
     handler: exitOnError(viewState)
 };
@@ -35,21 +50,9 @@ async function viewState(options) {
     const { accountId, prefix, finality, blockId, utf8 } = options;
     const near = await connect(options);
     const account = await near.account(accountId);
-    if (finality && blockId) {
-        console.error('Only one of --finality and --blockId can be provided');
-        process.exit(1);
-    } else if (!finality && !blockId) {
-        console.error('Must provide either --finality or --blockId');
-        process.exit(1);
-    }
+
     // near-api-js takes block_id instead of blockId
-    let block_id = blockId;
-    if (blockId && !isNaN(Number(blockId))) {
-        // If block id is a number (still string as command line args), it must be convert to JavaScript Number
-        // for near-api-js.
-        block_id = Number(blockId);
-    }
-    let state = await account.viewState(prefix, { block_id, finality });
+    let state = await account.viewState(prefix, { block_id: blockId, finality });
     if (utf8) {
         state = state.map(({ key, value}) => ({ key: key.toString('utf-8'), value: value.toString('utf-8') }));
     }

--- a/test/test_account_operations.sh
+++ b/test/test_account_operations.sh
@@ -15,4 +15,20 @@ if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     exit 1
 fi
 
+echo Get account storage --finality final
+RESULT=$(./bin/near view-state $testaccount --finality final)
+EXPECTED="[]"
+if [[ ! "$RESULT" == $EXPECTED ]]; then
+    echo FAILURE Unexpected output from near view-state
+    exit 1
+fi
+
+echo Get account storage --finality optimistic
+RESULT=$(./bin/near view-state $testaccount --finality optimistic)
+EXPECTED="[]"
+if [[ ! "$RESULT" == $EXPECTED ]]; then
+    echo FAILURE Unexpected output from near view-state
+    exit 1
+fi
+
 ./bin/near delete $testaccount test.near

--- a/test/test_account_operations.sh
+++ b/test/test_account_operations.sh
@@ -51,18 +51,32 @@ if [[ ! "$RESULT" == $EXPECTED ]]; then
     exit 1
 fi
 
-echo Get account storage --blockId $BLOCK_HASH --finality optimistic should fail
-EXPECTED="Only one of --finality and --blockId can be provided"
 set +e
+
+echo Get account storage --blockId $BLOCK_HASH --finality optimistic should fail
+EXPECTED="Arguments block-id and finality are mutually exclusive"
 ./bin/near view-state $testaccount --blockId $BLOCK_HASH  --finality optimistic 2> ${testaccount}.stderr
 if [[ ! $? == 1 ]]; then
     echo view-state should fail given both blockId and finality
     exit 1
 fi
-if [[ ! $(cat ${testaccount}.stderr) == $EXPECTED ]]; then
+if [[ ! $(cat ${testaccount}.stderr) =~ $EXPECTED ]]; then
     echo FAILURE Unexpected output from near view-state
     exit 1
 fi
+
+echo Get account storage without one of blockId or finality should fail
+EXPECTED="Must provide either --finality or --blockId"
+./bin/near view-state $testaccount 2> ${testaccount}.stderr
+if [[ ! $? == 1 ]]; then
+    echo view-state should fail without one of blockId or finality should fail
+    exit 1
+fi
+if [[ ! $(cat ${testaccount}.stderr) =~ $EXPECTED ]]; then
+    echo FAILURE Unexpected output from near view-state
+    exit 1
+fi
+
 set -e
 
 


### PR DESCRIPTION
I ran into #787 too. finality cannot simply be add as required param, because user need to specify one of blockid and finality and only one. Otherwise near-api-js fails. Also fixed two bugs:
1) passing blockid to near-api-js, which expects block_id and blockId cause crash; 
2) block_id could not take number, because command line arg was also considered as string and near-api-js tried to interpret it as block hash, fix by convert number like string to javascript string.
Result:
```
near-cli (fix-787) bin/near view-state simple-state.abcdef.testnet --blockId 51762759
[
  {
    key: <Buffer 53 54 41 54 45>,
    value: <Buffer 01 00 00 00 0e 00 00 00 61 62 63 64 65 66 2e 74 65 73 74 6e 65 74 05 00 00 00 68 65 6c 6c 6f>
  }
]
near-cli (fix-787) bin/near view-state simple-state.abcdef.testnet --blockId Fg4CVqhu1c1DdC5WegicGsE2NJYUB1K1wrwvvPPF1e4d
[
  {
    key: <Buffer 53 54 41 54 45>,
    value: <Buffer 01 00 00 00 0e 00 00 00 61 62 63 64 65 66 2e 74 65 73 74 6e 65 74 05 00 00 00 68 65 6c 6c 6f>
  }
]
near-cli (fix-787) bin/near view-state simple-state.abcdef.testnet --block-id 51762759 --finality final
Only one of --finality and --blockId can be provided
1|near-cli (fix-787) bin/near view-state simple-state.abcdef.testnet
Must provide either --finality or --blockId
1|near-cli (fix-787) bin/near view-state simple-state.abcdef.testnet --finality final
[
  {
    key: <Buffer 53 54 41 54 45>,
    value: <Buffer 01 00 00 00 0e 00 00 00 61 62 63 64 65 66 2e 74 65 73 74 6e 65 74 05 00 00 00 68 65 6c 6c 6f>
  }
]
```