### PR TITLE
feat: Add deposit yocto

### DIFF
--- a/commands/call.js
+++ b/commands/call.js
@@ -19,6 +19,11 @@ module.exports = {
             default: '0',
             alias: 'amount'
         })
+        .option('depositYocto', {
+            desc: 'Number of tokens to attach (in yocto NEAR) to a function call',
+            type: 'string',
+            default: null,
+        })
         .option('base64', {
             desc: 'Treat arguments as base64-encoded BLOB.',
             type: 'boolean',
@@ -39,8 +44,10 @@ module.exports = {
 
 async function scheduleFunctionCall(options) {
     await checkCredentials(options.accountId, options.networkId, options.keyStore);
+    const deposit = options.depositYocto ?? utils.format.parseNearAmount(options.deposit);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
-        (options.deposit && options.deposit != '0' ? ` with attached ${options.deposit} NEAR` : ''));
+        (deposit && deposit != '0' ? ` with attached ${utils.format.formatNearAmount(deposit)} NEAR` : ''));
+
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const parsedArgs = options.base64 ? Buffer.from(options.args, 'base64') : JSON.parse(options.args || '{}');
@@ -49,7 +56,7 @@ async function scheduleFunctionCall(options) {
         methodName: options.methodName,
         args: parsedArgs,
         gas: options.gas,
-        attachedDeposit: utils.format.parseNearAmount(options.deposit),
+        attachedDeposit: deposit,
     });
     const result = providers.getTransactionLastResult(functionCallResponse);
     inspectResponse.prettyPrintResponse(functionCallResponse, options);


### PR DESCRIPTION
Closes https://github.com/near/near-cli/issues/751

This only adds the `depositYocto` option to the call command. 

I didn't add it to other commands since they were still using `amount` as an option. Should we go ahead and change those to `deposit`/`depositYocto` as well?