### PR TITLE
Add a prompt warning about an existing contract on this account

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -122,12 +122,6 @@ const deploy = {
         })
         .alias({
             'accountId': ['account_id', 'contractName', 'contract_name'],
-        })
-        .option('force', {
-            desc: 'Forcefully deploy the contract even if there is already an existing contract',
-            type: 'boolean',
-            default: false,
-            alias: 'f'
         }),
     handler: exitOnError(main.deploy)
 };
@@ -225,6 +219,12 @@ yargs // eslint-disable-line
         type: 'boolean',
         alias: 'v',
         default: false
+    })
+    .option('force', {
+        desc: 'Forcefully execute the desired action even if it is unsafe to do so',
+        type: 'boolean',
+        default: false,
+        alias: 'f'
     })
     .middleware(require('../middleware/initial-balance'))
     .middleware(require('../middleware/print-options'))

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -122,6 +122,12 @@ const deploy = {
         })
         .alias({
             'accountId': ['account_id', 'contractName', 'contract_name'],
+        })
+        .option('force', {
+            desc: 'Forcefully deploy the contract even if there is already an existing contract',
+            type: 'boolean',
+            default: false,
+            alias: 'f'
         }),
     handler: exitOnError(main.deploy)
 };

--- a/index.js
+++ b/index.js
@@ -31,55 +31,60 @@ exports.clean = async function () {
     console.log('Clean complete.');
 };
 
+// Checks if there is an existing contract deployed on this account
+// (code hash consisting of 32 ones means that the contract code is missing).
+// Returns `true` if the contract is either missing or if the user agreed to replace it.
+// Returns `false` otherwise.
+const checkExistingContract = async function(prevCodeHash) {
+    if (prevCodeHash !== '11111111111111111111111111111111') {
+        return await askYesNoQuestion(
+            chalk`{bold.white This account already has a deployed contract [ {bold.blue ${prevCodeHash}} ]. Do you want to proceed? {bold.green (y/n) }}`,
+            false
+        );
+    }
+    return true;
+};
+
 exports.deploy = async function (options) {
     await checkCredentials(options.accountId, options.networkId, options.keyStore);
-    console.log(
-        `Starting deployment. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, file: ${options.wasmFile}`);
 
     const near = await connect(options);
     const account = await near.account(options.accountId);
     let prevState = await account.state();
     let prevCodeHash = prevState.code_hash;
 
-    // Checks if there is an existing contract deployed on this account
-    // (code hash consisting of 32 ones means that the contract code is missing)
-    if (!options.force && prevCodeHash !== '11111111111111111111111111111111') {
-        const answer = await askYesNoQuestion(
-            chalk`{bold.white This account already has a deployed contract [ {bold.blue ${prevCodeHash}} ]. Do you want to proceed? {bold.green (y/n) }}`,
-            false
-        );
-        if (!answer) {
-            process.exit(1);
+    if (options.force || await checkExistingContract(prevCodeHash)) {
+        console.log(
+            `Starting deployment. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, file: ${options.wasmFile}`);
+
+        // Deploy with init function and args
+        const txs = [transactions.deployContract(fs.readFileSync(options.wasmFile))];
+
+        if (options.initFunction) {
+            if (!options.initArgs) {
+                console.error('Must add initialization arguments.\nExample: near deploy --accountId near.testnet --initFunction "new" --initArgs \'{"key": "value"}\'');
+                await eventtracking.track(eventtracking.EVENT_ID_DEPLOY_END, { success: false, error: 'Must add initialization arguments' }, options);
+                process.exit(1);
+            }
+            txs.push(transactions.functionCall(
+                options.initFunction,
+                Buffer.from(options.initArgs),
+                options.initGas,
+                utils.format.parseNearAmount(options.initDeposit)),
+            );
         }
+
+        const result = await account.signAndSendTransaction({
+            receiverId: options.accountId,
+            actions: txs
+        });
+        inspectResponse.prettyPrintResponse(result, options);
+        let state = await account.state();
+        let codeHash = state.code_hash;
+        await eventtracking.track(eventtracking.EVENT_ID_DEPLOY_END, { success: true, code_hash: codeHash, is_same_contract: prevCodeHash === codeHash, contract_id: options.accountId }, options);
+        eventtracking.trackDeployedContract();
+        console.log(`Done deploying ${options.initFunction ? 'and initializing' : 'to'} ${options.accountId}`);
     }
-
-    // Deploy with init function and args
-    const txs = [transactions.deployContract(fs.readFileSync(options.wasmFile))];
-
-    if (options.initFunction) {
-        if (!options.initArgs) {
-            console.error('Must add initialization arguments.\nExample: near deploy --accountId near.testnet --initFunction "new" --initArgs \'{"key": "value"}\'');
-            await eventtracking.track(eventtracking.EVENT_ID_DEPLOY_END, { success: false, error: 'Must add initialization arguments' }, options);
-            process.exit(1);
-        }
-        txs.push(transactions.functionCall(
-            options.initFunction,
-            Buffer.from(options.initArgs),
-            options.initGas,
-            utils.format.parseNearAmount(options.initDeposit)),
-        );
-    }
-
-    const result = await account.signAndSendTransaction({
-        receiverId: options.accountId, 
-        actions: txs
-    });
-    inspectResponse.prettyPrintResponse(result, options);
-    let state = await account.state();
-    let codeHash = state.code_hash;
-    await eventtracking.track(eventtracking.EVENT_ID_DEPLOY_END, { success: true, code_hash: codeHash, is_same_contract: prevCodeHash === codeHash, contract_id: options.accountId }, options);
-    eventtracking.trackDeployedContract();
-    console.log(`Done deploying ${options.initFunction ? 'and initializing' : 'to'} ${options.accountId}`);
 };
 
 exports.callViewFunction = async function (options) {


### PR DESCRIPTION
Closes #876

This PR makes CLI output a prompt in the following format whenever an account already has an existing contract:
```
$ ./bin/near deploy --wasmFile ../NFT/res/non_fungible_token.wasm --accountId daniyar-near.testnet
Starting deployment. Account id: daniyar-near.testnet, node: https://rpc.testnet.near.org, helper: https://helper.testnet.near.org, file: ../NFT/res/non_fungible_token.wasm
This account already has a deployed contract [ 73ypSp7Ctk4eKh5odBbAD4H6jvYayKV7S2hhjTuMhp5R ]. Do you want to proceed? (y/n) n
```