### PR TITLE
Fix referrer title in the CLI login page

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,8 +110,8 @@ exports.login = async function (options) {
         await eventtracking.track(eventtracking.EVENT_ID_LOGIN_END, { success: true, login_is_not_needed: true }, options);
     } else {
         const newUrl = new URL(options.walletUrl + '/login/');
-        const title = 'NEAR CLI';
-        newUrl.searchParams.set('title', title);
+        const referrer = 'NEAR CLI';
+        newUrl.searchParams.set('referrer', referrer);
         const keyPair = await KeyPair.fromRandom('ed25519');
         newUrl.searchParams.set('public_key', keyPair.getPublicKey());
 


### PR DESCRIPTION
- [ ] Fix referrer title in the CLI login page
<img width="484" alt="Fix referrer title in the CLI login page" src="https://user-images.githubusercontent.com/126385/144040879-802ea0f9-ecf5-41cb-806a-c8ee5f683589.png">

The params of NEAR Wallet App title is `referrer` ([reference code](https://github.com/near/near-wallet/blob/63ea0d5be0ca8f324f1dca532e5207d02d48deb1/packages/frontend/src/redux/slices/account/index.js#L42))




