### PR TITLE
`delete-key` prompts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1257,6 +1257,8 @@ With NEAR REPL you have complete access to [`near-api-js`](https://github.com/ne
 | `--masterAccount`          |  Master account used when creating new accounts  [string]                                                                              |
 | `--helperAccount`          |  Expected top-level account for a network  [string]                                                                                    |
 | `-v, --verbose`            |  Prints out verbose output  [boolean] [default: false]                                                                                 |
+|`-f, --force`               |  Forcefully execute the desired action even if it is unsafe to do so  [boolean] [default: false]|
+
 
 > Got a question? <a href="https://stackoverflow.com/questions/tagged/nearprotocol"> <h8>Ask it on StackOverflow!</h8></a>
 

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -1,7 +1,9 @@
 const exitOnError = require('../utils/exit-on-error');
+const chalk = require('chalk');
 const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
 const checkCredentials = require('../utils/check-credentials');
+const { askYesNoQuestion } = require('../utils/readline');
 
 module.exports = {
     command: 'delete-key <account-id> <access-key>',
@@ -17,9 +19,32 @@ module.exports = {
 
 async function deleteAccessKey(options) {
     await checkCredentials(options.accountId, options.networkId, options.keyStore);
-    console.log(`Deleting key = ${options.accessKey} on ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);
-    const result = await account.deleteKey(options.accessKey);
-    inspectResponse.prettyPrintResponse(result, options);
+    if (options.force || await isAllApprovalsGranted(account, options.accessKey)) {
+        console.log(chalk`{bold.white Deleting key {bold.blue ${options.accessKey}} on {bold.blue ${options.accountId}.}}`);
+        const result = await account.deleteKey(options.accessKey);
+        inspectResponse.prettyPrintResponse(result, options);
+    } else {
+        console.log(chalk`{bold.white Deletion of {bold.blue  ${options.accessKey} } key on {bold.blue ${options.accountId}}. was {bold.red canceled}}`);
+    }
+}
+
+async function isAllApprovalsGranted(account, accessKey) {
+    let accessKeys = await account.getAccessKeys();
+    let fullAccessKeys = accessKeys.filter(accessKey => accessKey.access_key.permission === 'FullAccess');
+
+    // aks for approvals if user is deleting Full Access Key
+    if (fullAccessKeys.find(key => key.public_key === accessKey)) {
+        if (!await askYesNoQuestion(
+            chalk`{bold.white Key {bold.blue ${accessKey}} is a Full Access key. Make sure it's not your recovery method. Do you want to proceed? {bold.green (y/n) }}`,
+            false)
+        ) { return false; }
+        // ask additional questions if it's the last Full Access Key
+        if (fullAccessKeys.length === 1 && !await askYesNoQuestion(
+            chalk`{bold.white Key {bold.blue ${accessKey}} is the last Full Access key. In case of deletion, you will not be able to restore access to the account {bold.blue ${account.accountId}}. Do you want to proceed? {bold.green (y/n) }}`,
+            false)
+        ) { return false; }
+    }
+    return true;
 }

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -34,7 +34,7 @@ async function isAllApprovalsGranted(account, accessKey) {
     let accessKeys = await account.getAccessKeys();
     let fullAccessKeys = accessKeys.filter(accessKey => accessKey.access_key.permission === 'FullAccess');
 
-    // aks for approvals if user is deleting Full Access Key
+    // asks for approval if user is deleting Full Access Key
     if (fullAccessKeys.find(key => key.public_key === accessKey)) {
         if (!await askYesNoQuestion(
             chalk`{bold.white Key {bold.blue ${accessKey}} is a Full Access key. Make sure it's not your recovery method. Do you want to proceed? {bold.green (y/n) }}`,
@@ -42,7 +42,7 @@ async function isAllApprovalsGranted(account, accessKey) {
         ) { return false; }
         // ask additional questions if it's the last Full Access Key
         if (fullAccessKeys.length === 1 && !await askYesNoQuestion(
-            chalk`{bold.white Key {bold.blue ${accessKey}} is the last Full Access key. In case of deletion, you will not be able to restore access to the account {bold.blue ${account.accountId}}. Do you want to proceed? {bold.green (y/n) }}`,
+            chalk`{bold.white Key {bold.blue ${accessKey}} is the last Full Access key on your account. In case of deleting you will not be able to restore access to the account {bold.blue ${account.accountId}}. Do you want to proceed? {bold.green (y/n) }}`,
             false)
         ) { return false; }
     }


### PR DESCRIPTION
Closing #834 
Current output:
```bash

~/P/N/near-cli on last-key-deletion ⨯ ./bin/near keys keystest.serhii.testnet

Keys for account keystest.serhii.testnet
[
  {
    public_key: 'ed25519:2iQAzcDvdSVMReXi2NVvhANrYdHBcMXnSWZz7mdBii5P',
    access_key: { nonce: 73345990000006, permission: 'FullAccess' }
  },
  {
    public_key: 'ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P',
    access_key: { nonce: 73346143000000, permission: 'FullAccess' }
  },
  {
    public_key: 'ed25519:GkMNfc92fwM1AmwH1MTjF4b7UZuceamsq96XPkHsQ9vi',
    access_key: {
      nonce: 73347044000000,
      permission: {
        FunctionCall: {
          allowance: '30000000000000000000000000000000000',
          receiver_id: 'example-contract.testnet',
          method_names: [ 'example_method' ]
        }
      }
    }
  }
]

⋊> ~/P/N/near-cli on last-key-deletion ⨯ ./bin/near delete-key keystest.serhii.testnet ed25519:GkMNfc92fwM1AmwH1MTjF4b7UZuceamsq96XPkHsQ9vi

Deleting key ed25519:GkMNfc92fwM1AmwH1MTjF4b7UZuceamsq96XPkHsQ9vi on keystest.serhii.testnet.
Transaction Id DXQtAbWAVKL2HrfTzdzCf7cQCnn7bUMZNuaZ2dKJ2amN
To see the transaction in the transaction explorer, please open this url in your browser
https://explorer.testnet.near.org/transactions/DXQtAbWAVKL2HrfTzdzCf7cQCnn7bUMZNuaZ2dKJ2amN

⋊> ~/P/N/near-cli on last-key-deletion ⨯ ./bin/near delete-key keystest.serhii.testnet ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P

Key ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P ] is a Full Access key. Make sure it's not your recovery method. Do you want to proceed? (y/n) n
Deletion of  ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P  key on keystest.serhii.testnet. was canceled

⋊> ~/P/N/near-cli on last-key-deletion ⨯ ./bin/near delete-key keystest.serhii.testnet ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P

Key ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P ] is a Full Access key. Make sure it's not your recovery method. Do you want to proceed? (y/n) y
Deleting key ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P on keystest.serhii.testnet.
Transaction Id EKheTmgnK2212CtHTXAStKRLhEURpESBN7n22AxAXN1E
To see the transaction in the transaction explorer, please open this url in your browser
https://explorer.testnet.near.org/transactions/EKheTmgnK2212CtHTXAStKRLhEURpESBN7n22AxAXN1E

⋊> ~/P/N/near-cli on last-key-deletion ⨯ ./bin/near add-key keystest.serhii.testnet ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P

Adding full access key = ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P to keystest.serhii.testnet.
Transaction Id 4igCtMDda2MKGDvdxC8wBuZrE26SKnRFcUG8UYpnzYF9
To see the transaction in the transaction explorer, please open this url in your browser
https://explorer.testnet.near.org/transactions/4igCtMDda2MKGDvdxC8wBuZrE26SKnRFcUG8UYpnzYF9

⋊> ~/P/N/near-cli on last-key-deletion ⨯ ./bin/near delete-key keystest.serhii.testnet ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P --force

Deleting key ed25519:6HtbSyKVtSasm5vvtvN5LevdyzCt3L6dNgkMnXK7Sw4P on keystest.serhii.testnet.
Transaction Id 9Ltbk5oMBay2n2WfJJXBygEYgjBnUysvz36vXVKDjjVb
To see the transaction in the transaction explorer, please open this url in your browser
https://explorer.testnet.near.org/transactions/9Ltbk5oMBay2n2WfJJXBygEYgjBnUysvz36vXVKDjjVb

⋊> ~/P/N/near-cli on last-key-deletion ⨯ ./bin/near delete-key keystest.serhii.testnet ed25519:2iQAzcDvdSVMReXi2NVvhANrYdHBcMXnSWZz7mdBii5P

Key ed25519:2iQAzcDvdSVMReXi2NVvhANrYdHBcMXnSWZz7mdBii5P ] is a Full Access key. Make sure it's not your recovery method. Do you want to proceed? (y/n) y
Key [ ed25519:2iQAzcDvdSVMReXi2NVvhANrYdHBcMXnSWZz7mdBii5P ] is the last Full Access key. In case of deletion, you will not be able to restore access to the account [ keystest.serhii.testnet ]. Do you want to proceed? (y/n) y
Deleting key ed25519:2iQAzcDvdSVMReXi2NVvhANrYdHBcMXnSWZz7mdBii5P on keystest.serhii.testnet.
Transaction Id Na8qbutSkkuVyFnynCQKq3vPHVE5QTx6EEs2DmbK1xG
To see the transaction in the transaction explorer, please open this url in your browser
https://explorer.testnet.near.org/transactions/Na8qbutSkkuVyFnynCQKq3vPHVE5QTx6EEs2DmbK1xG

⋊> ~/P/N/near-cli on last-key-deletion ⨯ ./bin/near keys keystest.serhii.testnet                                                                       
Keys for account keystest.serhii.testnet
[]
```