### PR TITLE
Fix for https://github.com/near/near-cli/issues/786

### DIFF
--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -47,7 +47,6 @@ module.exports = {
 
         // If key doesn't exist, create one and store in the keyStore.
         // Otherwise, it's expected that both key and accountId are already provided in arguments.
-
         if (!argv.publicKey) {
             const keyPair = KeyPair.fromRandom('ed25519');
             argv.publicKey = keyPair.publicKey.toString();

--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -9,6 +9,10 @@ module.exports = {
         .option('yolo', {
             description: 'Do not ask for extra confirmation when using Ledger',
             type: 'boolean',
+        })
+        .option('seedPhrase', {
+            description: 'Seed phrase mnemonic',
+            type: 'string',
         }),
     handler: exitOnError(async (argv) => {
         let near = await require('../utils/connect')(argv);
@@ -36,13 +40,14 @@ module.exports = {
 
         const { deps: { keyStore } } = near.config;
         const existingKey = await keyStore.getKey(argv.networkId, argv.accountId);
-        if (existingKey) {
+        if (existingKey && !argv.seedPhrase) {
             console.log(`Account has existing key pair with ${existingKey.publicKey} public key`);
             return;
         }
 
         // If key doesn't exist, create one and store in the keyStore.
         // Otherwise, it's expected that both key and accountId are already provided in arguments.
+
         if (!argv.publicKey) {
             const keyPair = KeyPair.fromRandom('ed25519');
             argv.publicKey = keyPair.publicKey.toString();


### PR DESCRIPTION
If the seed phrase is used on the command line regardless of position, the seed-phrase middleware creates a key and adds it to the keystore.  This change considers that fact and eliminates output of the confusing message.

Also added the seedPhrase yargs option as it seems to be supported per how things work and even per the comment here:
https://github.com/near/near-cli/blob/63cd30cc27a3cefd9ff48c6d4e9b4b26816bb0ed/middleware/seed-phrase.js#L8

