### PR TITLE
fix: typeerror when running near

### DIFF
--- a/get-config.js
+++ b/get-config.js
@@ -1,6 +1,6 @@
 
 module.exports = function getConfig() {
-    const configPath = process.cwd() + '/src/config';
+    const configPath = process.cwd() + '/config.js';
     const nearEnv = process.env.NEAR_ENV || process.env.NODE_ENV || 'development';
     try {
         const config = require(configPath)(nearEnv);


### PR DESCRIPTION
This pull request solves the issue #923 by changing the config path in `get-config.js` to `config.js`.