### PR TITLE
Hit the node on IPv4 localhost rather than hostname by default

### DIFF
--- a/config.js
+++ b/config.js
@@ -54,7 +54,7 @@ function getConfig(env) {
     case 'localnet':
         config = {
             networkId: process.env.NEAR_CLI_LOCALNET_NETWORK_ID || 'local',
-            nodeUrl: process.env.NEAR_CLI_LOCALNET_RPC_SERVER_URL || process.env.NEAR_NODE_URL || 'http://localhost:3030',
+            nodeUrl: process.env.NEAR_CLI_LOCALNET_RPC_SERVER_URL || process.env.NEAR_NODE_URL || 'http://127.0.0.1:3030',
             keyPath: process.env.NEAR_CLI_LOCALNET_KEY_PATH || `${process.env.HOME}/.near/validator_key.json`,
             walletUrl: process.env.NEAR_WALLET_URL || 'http://localhost:4000/wallet',
             contractName: CONTRACT_NAME,


### PR DESCRIPTION
The localnet local node (probably the only reason for this default value) defaults to listening only on IPv4.

Instead of defaulting on hostname-localhost, which would break on systems that default localhost to `::1`, use `127.0.0.1` by default.

The better fix would be to actually have the node listen on IPv6, but this should be better than the current situation at least.

Fixes #881