### PR TITLE
fix: add `x-api-key` header only when key is available

### DIFF
--- a/config.js
+++ b/config.js
@@ -79,7 +79,7 @@ function getConfig(env) {
     // adding x-api-key for given RPC Server
     const apiKey = getXApiKey(config.nodeUrl);
     if (apiKey) {
-        config.headers = { 'x-api-key': getXApiKey(config.nodeUrl) };
+        config.headers = { 'x-api-key': apiKey };
     }
     return config;
 }

--- a/config.js
+++ b/config.js
@@ -77,7 +77,10 @@ function getConfig(env) {
     }
 
     // adding x-api-key for given RPC Server
-    config.headers = { 'x-api-key': getXApiKey(config.nodeUrl) };
+    const apiKey = getXApiKey(config.nodeUrl);
+    if (apiKey) {
+        config.headers = { 'x-api-key': getXApiKey(config.nodeUrl) };
+    }
     return config;
 }
 


### PR DESCRIPTION
We received feedback from developer that when using `near-cli` with some RPC node service providers, it failed to work because a `undefined` x-api-key header is provided when it's actually not needed. 

e.g. `near state nearkat.testnet --nodeUrl https://hk.bsngate.com/api/969ae9025c789b565f20817be86b95653bcfa07adaf6d9add730c817456b0cc2/Near-Testnet/rpc`

To fix this, set x-api-key header only when the key is available. 