### PR TITLE
943 initFunction and initArgs logic is wrong

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -105,7 +105,8 @@ const deploy = {
         })
         .option('initFunction', {
             desc: 'Initialization method',
-            type: 'string'
+            type: 'string',
+            default: 'new'
         })
         .option('initArgs', {
             desc: 'Initialization arguments',

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -27,7 +27,8 @@ module.exports = {
         })
         .option('initFunction', {
             desc: 'Initialization method',
-            type: 'string'
+            type: 'string',
+            default: 'new'
         })
         .option('initArgs', {
             desc: 'Initialization arguments',


### PR DESCRIPTION
Use "new" if `--initArgs` is provided but `--initFunction` is not. fixes #943 

@nearmax 
@volovyk-s 