### PR TITLE
fix: throw exception and then return exit(1) on call with error

### DIFF
--- a/commands/call.js
+++ b/commands/call.js
@@ -70,10 +70,8 @@ async function scheduleFunctionCall(options) {
             handleExceededThePrepaidGasError(error, options);
             break;
         }
-        default: {
-            console.log(error);
         }
-        }
+        throw error; 
     }
 }
 


### PR DESCRIPTION
Hi!

I found the missing process.exit(1) after an error during functionCall.

Expected example:
```
./bin/near call usn unknown_method '{}' --accountId kalloc.testnet > /dev/null;echo $?
        Failure [usn]: Error: Can't complete the action because account usn doesn't exist
…
}
1
```
