### PR TITLE
feat: store view and call result to file

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -223,6 +223,11 @@ yargs // eslint-disable-line
         desc: 'Base url for explorer',
         type: 'string',
     })
+    .option('output', {
+        desc: 'File to store the result',
+        type: 'string',
+        alias: 'o',
+    })
     .option('verbose', {
         desc: 'Prints out verbose output',
         type: 'boolean',

--- a/commands/call.js
+++ b/commands/call.js
@@ -1,3 +1,4 @@
+const fs = require('fs/promises');
 const { DEFAULT_FUNCTION_CALL_GAS, providers, utils } = require('near-api-js');
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
@@ -9,6 +10,11 @@ module.exports = {
     command: 'call <contractName> <methodName> [args]',
     desc: 'schedule smart contract call which can modify state',
     builder: (yargs) => yargs
+        .option('output', {
+            desc: 'File to store the result',
+            type: 'string',
+            alias: 'o',
+        })
         .option('gas', {
             desc: 'Max amount of gas this call can use (in gas units)',
             type: 'string',
@@ -64,6 +70,9 @@ async function scheduleFunctionCall(options) {
         const result = providers.getTransactionLastResult(functionCallResponse);
         inspectResponse.prettyPrintResponse(functionCallResponse, options);
         console.log(inspectResponse.formatResponse(result));
+        if (options.output) {
+            await fs.writeFile(options.output, JSON.stringify(result, null, 4));
+        }
     } catch (error) {
         switch (JSON.stringify(error.kind)) {
         case '{"ExecutionError":"Exceeded the prepaid gas."}': {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs/promises');
 const yargs = require('yargs');
 const ncp = require('ncp').ncp;
 ncp.limit = 16;
@@ -91,7 +91,11 @@ exports.callViewFunction = async function (options) {
     console.log(`View call: ${options.contractName}.${options.methodName}(${options.args || ''})`);
     const near = await connect(options);
     const account = await near.account(options.accountId || options.masterAccount || options.contractName);
-    console.log(inspectResponse.formatResponse(await account.viewFunction(options.contractName, options.methodName, JSON.parse(options.args || '{}'))));
+    const respone = await account.viewFunction(options.contractName, options.methodName, JSON.parse(options.args || '{}'));
+    console.log(inspectResponse.formatResponse(respone));
+    if (options.output) {
+        await fs.writeFile(options.output, JSON.stringify(respone, null, 4));
+    }
 };
 
 // open a given URL in browser in a safe way.


### PR DESCRIPTION
It would be very useful for bash scripting.

Example usage:

```
$ ./bin/near call REDACTED  nft_mint '{…REDACTED…}' --accountId REDACTED --deposit 1 -o 1.json >/dev/null ; cat 1.json | jq .token_id

"16"


```