### PR TITLE
chore: Remove requirement for specifying accountId for js view

### DIFF
--- a/commands/js.js
+++ b/commands/js.js
@@ -150,7 +150,6 @@ const js_view = {
         .option('accountId', {
             desc: 'Unique identifier for the account that will be used to sign this call',
             type: 'string',
-            required: true,
         })
         .option('args', {
             desc: 'Arguments to the contract call, in JSON format by default (e.g. \'{"param_a": "value"}\')',


### PR DESCRIPTION
this forces people to specify the signer for `near js view`, so removed the requirement and have the signer be whatever. This isn't really even signing anything, just an oddity of `near-api-js` requiring an account-id to create an account, to then make a view call