### PR TITLE
Make CLI Version Suggestion Global Instead of Local

### DIFF
--- a/utils/check-version.js
+++ b/utils/check-version.js
@@ -37,7 +37,7 @@ Run {cyan ${updateCommand}} to avoid unexpected behavior`;
             borderStyle: 'round'
         };
 
-        notifier.notify({ message, boxenOpts });
+        notifier.notify({ message, boxenOpts, isGlobal: true });
     }
 };
 


### PR DESCRIPTION
Previous NEAR CLI notifications would recommend running a local command to upgrade the near-cli: 

![image](https://user-images.githubusercontent.com/10233439/171378688-42169aa2-5b44-4f2b-8036-fc119c54ae7f.png)

This would create errors when running from within a project with dependencies that are not supported for the environment of the machine. 

This PR changes these notifications to include a global flag:

<img width="344" alt="image" src="https://user-images.githubusercontent.com/10233439/171378654-562d846d-ad64-4d9f-8527-238efbac89f2.png">
