### PR TITLE
Create seed phrase option on add-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,30 @@ near add-key example-acct.testnet GkMNfc92fwM1AmwH1MTjF4b7UZuceamsq96XPkHsQ9vi -
 </p>
 </details>
 
+
+#### 3) add a `full access` key based on a seed phrase
+
+-   arguments: `accountId` `--seedPhrase="[your seed phrase]"`
+
+**Example:**
+
+```bash
+near add-key example-acct.testnet --seedPhrase="cow moon right send now cool dense quark pretty see light after"
+```
+
+<details>
+<summary><strong>Example Response</strong></summary>
+<p>
+
+    Adding seed phrase as full access key = "cow moon right send now cool dense quark pretty see light after" to example-acct.testnet.
+    Transaction Id EwU1ooEvkR42HvGoJHu5ou3xLYT3JcgQwFV3fAwevGJg
+    To see the transaction in the transaction explorer, please open this url in your browser
+    https://explorer.testnet.near.org/transactions/EwU1ooEvkR42HvGoJHu5ou3xLYT3JcgQwFV3fAwevGJg
+
+</p>
+</details>
+
+
 ---
 
 ### `near delete-key`

--- a/commands/add-key.js
+++ b/commands/add-key.js
@@ -5,13 +5,13 @@ const { utils } = require('near-api-js');
 const checkCredentials = require('../utils/check-credentials');
 
 module.exports = {
-    command: 'add-key <account-id> <access-key>',
+    command: 'add-key <account-id>',
     desc: 'Add an access key to given account',
     builder: (yargs) => yargs
         .option('access-key', {
             desc: 'Public key to add (base58 encoded)',
             type: 'string',
-            required: true,
+            required: false,
         })
         .option('contract-id', {
             desc: 'Limit access key to given contract (if not provided - will create full access key)',
@@ -33,9 +33,24 @@ module.exports = {
 
 async function addAccessKey(options) {
     await checkCredentials(options.accountId, options.networkId, options.keyStore);
-    console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);
+
+    if(options.seedPhrase){
+        if(options.contractId){
+            console.log("Seed phrase key must be a full access key");
+            return;
+        }
+        console.log(`Adding seed phrase as full access key = "${options.seedPhrase}" to ${options.accountId}`);
+
+        const result = await account.addKey(options.seedPhrasePublicKey);
+        inspectResponse.prettyPrintResponse(result, options);
+
+        return;
+    }
+
+    console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key = ${options.accessKey} to ${options.accountId}.`);
+    
     const allowance = utils.format.parseNearAmount(options.allowance);
     const result = await account.addKey(options.accessKey, options.contractId, options.methodNames, allowance);
     inspectResponse.prettyPrintResponse(result, options);

--- a/middleware/seed-phrase.js
+++ b/middleware/seed-phrase.js
@@ -18,8 +18,8 @@ module.exports = async function useSeedPhrase({ seedPhrase, seedPath, keyStore, 
     const seedPhraseKeystore = new InMemoryKeyStore();
     const seedPhraseAccountId = masterAccount ? masterAccount : accountId || implicitAccountId(publicKey);
 
-    await keyStore.setKey(networkId, seedPhraseAccountId, KeyPair.fromString(secretKey));
+    await seedPhraseKeystore.setKey(networkId, seedPhraseAccountId, KeyPair.fromString(secretKey));
     if(keyStore instanceof MergeKeyStore) keyStore.keyStores.push(seedPhraseKeystore);
 
-    return { keyStore, accountId };
+    return { keyStore, accountId, seedPhrasePublicKey: publicKey };
 };


### PR DESCRIPTION
The problem:
There is currently no way in the CLI to add a seed phrase to an already existing account. As a result, if an account was generated on the CLI, it is not easy to also add it on the web wallet.

The solution:
If `add-key` is called not with a public key, but with the `--seedPhrase` option, the key generated by that seed phrase is added to the account