### PR TITLE
refactor: check if beneficiary account exists, require confirmation

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -32,7 +32,7 @@ const viewAccount = {
 
 const deleteAccount = {
     command: 'delete <accountId> <beneficiaryId>',
-    desc: 'delete an account and transfer funds to beneficiary account.',
+    desc: 'delete an account and transfer Near tokens to beneficiary account.',
     builder: (yargs) => yargs
         .option('accountId', {
             desc: 'Account to delete',

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ const confirmDelete = function () {
     return askYesNoQuestion(
         chalk`{bold.white This method will delete your account. Beneficiary account must exist in order to transfer all Near tokens. Make sure to send all fungible tokens or NFTs that you own to the beneficiary account prior to deleting, as this method will only transfer NEAR tokens. Do you want to proceed? {bold.green (y/n) }}`,
         false);
-}
+};
 
 exports.deploy = async function (options) {
     await checkCredentials(options.accountId, options.networkId, options.keyStore);
@@ -225,7 +225,7 @@ exports.deleteAccount = async function (options) {
     const beneficiaryAccount = await near.account(options.beneficiaryId);
     // beneficiary account does not exist if there are no access keys
     if (!(await beneficiaryAccount.getAccessKeys()).length) {
-        console.log("Beneficiary account does not exist, please create the account to transfer Near tokens.");
+        console.log('Beneficiary account does not exist, please create the account to transfer Near tokens.');
         return;
     }
     

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const checkExistingContract = async function(prevCodeHash) {
 
 const confirmDelete = function () {
     return askYesNoQuestion(
-        chalk`{bold.white This method will delete your account. Beneficiary account must exist in order to transfer all Near tokens. Make sure to send all fungible tokens or NFTs that you own to the beneficiary account prior to deleting, as this method will only transfer NEAR tokens. Do you want to proceed? {bold.green (y/n) }}`,
+        chalk`{bold.white This method will delete your account. Beneficiary account must already be initialized in order to transfer all Near tokens. Make sure to send all fungible tokens or NFTs that you own to the beneficiary account prior to deleting, as this method will only transfer NEAR tokens. Do you want to proceed? {bold.green (y/n) }}`,
         false);
 };
 

--- a/index.js
+++ b/index.js
@@ -45,6 +45,12 @@ const checkExistingContract = async function(prevCodeHash) {
     return true;
 };
 
+const confirmDelete = function () {
+    return askYesNoQuestion(
+        chalk`{bold.white This method will delete your account. Beneficiary account must exist in order to transfer all Near tokens. Make sure to send all fungible tokens or NFTs that you own to the beneficiary account prior to deleting, as this method will only transfer NEAR tokens. Do you want to proceed? {bold.green (y/n) }}`,
+        false);
+}
+
 exports.deploy = async function (options) {
     await checkCredentials(options.accountId, options.networkId, options.keyStore);
 
@@ -215,13 +221,25 @@ exports.viewAccount = async function (options) {
 
 exports.deleteAccount = async function (options) {
     await checkCredentials(options.accountId, options.networkId, options.keyStore);
-    console.log(
-        `Deleting account. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, beneficiary: ${options.beneficiaryId}`);
     const near = await connect(options);
-    const account = await near.account(options.accountId);
-    const result = await account.deleteAccount(options.beneficiaryId);
-    inspectResponse.prettyPrintResponse(result, options);
-    console.log(`Account ${options.accountId} for network "${options.networkId}" was deleted.`);
+    const beneficiaryAccount = await near.account(options.beneficiaryId);
+    // beneficiary account does not exist if there are no access keys
+    if (!(await beneficiaryAccount.getAccessKeys()).length) {
+        console.log("Beneficiary account does not exist, please create the account to transfer Near tokens.");
+        return;
+    }
+    
+    if (await confirmDelete()) {
+        const account = await near.account(options.accountId);
+        console.log(
+            `Deleting account. Account id: ${options.accountId}, node: ${options.nodeUrl}, helper: ${options.helperUrl}, beneficiary: ${options.beneficiaryId}`);
+        const result = await account.deleteAccount(options.beneficiaryId);
+        inspectResponse.prettyPrintResponse(result, options);
+        console.log(`Account ${options.accountId} for network "${options.networkId}" was deleted.`);
+    }
+    else {
+        console.log(chalk`{bold.white Deletion of account with account id: {bold.blue  ${options.accountId} } was {bold.red canceled}}`);
+    }
 };
 
 exports.keys = async function (options) {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const checkExistingContract = async function(prevCodeHash) {
 
 const confirmDelete = function () {
     return askYesNoQuestion(
-        chalk`{bold.white This method will delete your account. Beneficiary account must already be initialized in order to transfer all Near tokens. Make sure to send all fungible tokens or NFTs that you own to the beneficiary account prior to deleting, as this method will only transfer NEAR tokens. Do you want to proceed? {bold.green (y/n) }}`,
+        chalk`{bold.white This method will delete your account. Beneficiary account must already be initialized in order to transfer all Near tokens or these will be lost. Make sure to send all fungible tokens or NFTs that you own to the beneficiary account prior to deleting, as this method will only transfer NEAR tokens. Do you want to proceed? {bold.green (y/n) }}`,
         false);
 };
 


### PR DESCRIPTION
related to issue https://github.com/near/near-cli/issues/994

PR adds a warning `This method will delete your account. Beneficiary account must exist in order to transfer all Near tokens. Make sure to send all fungible tokens or NFTs that you own to the beneficiary account prior to deleting, as this method will only transfer NEAR tokens. Do you want to proceed?` that the user must confirm.

Delete will also not run if beneficiary account does not exist.