### PR TITLE
Fixing generate-key with --seedPhrase

### DIFF
--- a/middleware/seed-phrase.js
+++ b/middleware/seed-phrase.js
@@ -18,8 +18,11 @@ module.exports = async function useSeedPhrase({ seedPhrase, seedPath, keyStore, 
     const seedPhraseKeystore = new InMemoryKeyStore();
     const seedPhraseAccountId = masterAccount ? masterAccount : accountId || implicitAccountId(publicKey);
 
+    console.log(`Adding a seed-based key ${publicKey} to account ${seedPhraseAccountId}`);
+    // FIXME: something is wrong here - as we create the "seedPhraseKeystore", but it stays "empty"
+    // and we add the seed-based key directly into "main" keystore.
     await keyStore.setKey(networkId, seedPhraseAccountId, KeyPair.fromString(secretKey));
-    if(keyStore instanceof MergeKeyStore) keyStore.keyStores.push(seedPhraseKeystore);
+    if (keyStore instanceof MergeKeyStore) keyStore.keyStores.push(seedPhraseKeystore);
 
-    return { keyStore, accountId };
+    return { keyStore, accountId, seedPhraseAccountId };
 };


### PR DESCRIPTION
Currently when you call

near --generate-key --seedPhrase a b c .. 

It will create 2 implicit keys (one with the seedPhrase and the other one with random value) - which is a little bit confusing.

Moreover, I think that something's wrong with seed-phrase.js code - as it should probably store the key in a seedPhraseKeystore (but I'm not very familiar with this code).