### PR TITLE
Fix Check for Existing Beneficiary in Account Deletion & Repair CI

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,9 +224,15 @@ exports.deleteAccount = async function (options) {
     const near = await connect(options);
     const beneficiaryAccount = await near.account(options.beneficiaryId);
     // beneficiary account does not exist if there are no access keys
-    if (!(await beneficiaryAccount.getAccessKeys()).length) {
-        console.log('Beneficiary account does not exist, please create the account to transfer Near tokens.');
-        return;
+    try {
+        await beneficiaryAccount.state();
+    } catch (e) {
+        if (e.type === 'AccountDoesNotExist') {
+            console.error(`Beneficiary account ${options.beneficiaryId} does not exist. Please create the account to transfer Near tokens.`);
+            return;
+        } else {
+            throw e;
+        }
     }
     
     if (await confirmDelete()) {

--- a/index.js
+++ b/index.js
@@ -244,7 +244,7 @@ exports.deleteAccount = async function (options) {
         console.log(`Account ${options.accountId} for network "${options.networkId}" was deleted.`);
     }
     else {
-        console.log(chalk`{bold.white Deletion of account with account id: {bold.blue  ${options.accountId} } was {bold.red canceled}}`);
+        console.log(chalk`{bold.white Deletion of account with account id: {bold.blue  ${options.accountId} } was {bold.red cancelled}}`);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pretest": "rm -rf tmp-project",
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "jest",
-    "test:integration": "./test/index.sh",
+    "test:integration": "bash ./test/index.sh",
     "lint": "eslint .",
     "fix": "eslint . --fix"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "main": "index.js",
   "scripts": {
     "pretest": "rm -rf tmp-project",
-    "test": "jest && ./test/index.sh",
+    "test": "npm run test:unit && npm run test:integration",
+    "test:unit": "jest",
+    "test:integration": "./test/index.sh",
     "lint": "eslint .",
     "fix": "eslint . --fix"
   },

--- a/test/test_deploy_init_contract.sh
+++ b/test/test_deploy_init_contract.sh
@@ -2,7 +2,7 @@
 set -e
 
 timestamp=$(date +%s)
-testaccount=testaccount$timestamp$RANDOM$RANDOM.test.near
+testaccount=testaccount$timestamp$RANDOM.test.near
 
 echo Creating account
 ./bin/near create-account $testaccount > /dev/null

--- a/test/test_deploy_init_contract.sh
+++ b/test/test_deploy_init_contract.sh
@@ -20,8 +20,7 @@ fi
 
 # Delete account, remake, redeploy
 echo Deleting account: $testaccount
-./bin/near delete $testaccount test.near > /dev/null
-sleep 5
+yes | ./bin/near delete $testaccount test.near > /dev/null
 echo Recreating account: $testaccount
 ./bin/near create-account $testaccount > /dev/null
 ./bin/near deploy --accountId $testaccount --wasmFile ./test/res/fungible_token.wasm --initFunction new --initArgs '{"owner_id": "test.near", "total_supply": "1000000"}' > /dev/null

--- a/test/test_deploy_init_contract.sh
+++ b/test/test_deploy_init_contract.sh
@@ -20,6 +20,7 @@ fi
 
 # Delete account, remake, redeploy
 ./bin/near delete $testaccount test.near > /dev/null
+sleep 5
 ./bin/near create-account $testaccount > /dev/null
 ./bin/near deploy --accountId $testaccount --wasmFile ./test/res/fungible_token.wasm --initFunction new --initArgs '{"owner_id": "test.near", "total_supply": "1000000"}' > /dev/null
 RESULT=$(./bin/near view $testaccount get_balance '{"owner_id": "test.near"}' -v | ./node_modules/.bin/strip-ansi)

--- a/test/test_deploy_init_contract.sh
+++ b/test/test_deploy_init_contract.sh
@@ -19,8 +19,10 @@ else
 fi
 
 # Delete account, remake, redeploy
+echo Deleting account: $testaccount
 ./bin/near delete $testaccount test.near > /dev/null
 sleep 5
+echo Recreating account: $testaccount
 ./bin/near create-account $testaccount > /dev/null
 ./bin/near deploy --accountId $testaccount --wasmFile ./test/res/fungible_token.wasm --initFunction new --initArgs '{"owner_id": "test.near", "total_supply": "1000000"}' > /dev/null
 RESULT=$(./bin/near view $testaccount get_balance '{"owner_id": "test.near"}' -v | ./node_modules/.bin/strip-ansi)

--- a/test/test_deploy_init_contract.sh
+++ b/test/test_deploy_init_contract.sh
@@ -2,7 +2,7 @@
 set -e
 
 timestamp=$(date +%s)
-testaccount=testaccount$timestamp$RANDOM.test.near
+testaccount=testaccount$timestamp$RANDOM$RANDOM.test.near
 
 echo Creating account
 ./bin/near create-account $testaccount > /dev/null

--- a/test/test_deploy_init_contract.sh
+++ b/test/test_deploy_init_contract.sh
@@ -20,7 +20,7 @@ fi
 
 # Delete account, remake, redeploy
 echo Deleting account: $testaccount
-yes | ./bin/near delete $testaccount test.near > /dev/null
+printf 'y\n' | ./bin/near delete $testaccount test.near > /dev/null
 echo Recreating account: $testaccount
 ./bin/near create-account $testaccount > /dev/null
 ./bin/near deploy --accountId $testaccount --wasmFile ./test/res/fungible_token.wasm --initFunction new --initArgs '{"owner_id": "test.near", "total_supply": "1000000"}' > /dev/null


### PR DESCRIPTION
This PR seeks to address the following two unaddressed subjects from https://github.com/near/near-cli/pull/999: 

1. The conditional check during `deleteAccount()` now ultimately performs a `view_account` RPC call instead of searching for keys to determine whether a ben. account exists
2. The test bash script is now fixed (allowing CI to pass) as deleting an account now requires user confirmation 