### PR TITLE
Fix slow Segment calls

### DIFF
--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -54,10 +54,6 @@ const track = async (eventType, eventProperties, options) => {
             const accountID = options.accountId;
             const id = getSegmentID(shellSettings);
             analytics.alias({ previousId: accountID, userId: id });
-            analytics.identify({
-                userId: id,
-                traits: { account_id: accountID }
-            });
         }
 
         const user_country = await getUserCountry();


### PR DESCRIPTION
Apparently, making `identify` calls is very expensive, and Segment documentation suggests to only do it once (when user signs up, logs in etc). I think we should be fine without making `identify` calls at all as `alias` is doing the same thing in our specific use case.

Reduces `near view-state accountname.testnet --finality final` execution time from 10s to <1s on my machine.