### PR TITLE
fix: generate-key-using-seed-phrase

### DIFF
--- a/middleware/seed-phrase.js
+++ b/middleware/seed-phrase.js
@@ -18,7 +18,7 @@ module.exports = async function useSeedPhrase({ seedPhrase, seedPath, keyStore, 
     const seedPhraseKeystore = new InMemoryKeyStore();
     const seedPhraseAccountId = masterAccount ? masterAccount : accountId || implicitAccountId(publicKey);
 
-    await keyStore.setKey(networkId, seedPhraseAccountId, KeyPair.fromString(secretKey));
+    await seedPhraseKeystore.setKey(networkId, seedPhraseAccountId, KeyPair.fromString(secretKey));
     if(keyStore instanceof MergeKeyStore) keyStore.keyStores.push(seedPhraseKeystore);
 
     return { keyStore, accountId };


### PR DESCRIPTION
fix issue #949 

* The wrong keyStore variable was used before, resulting in two key pair files generated when using `near generate-key --seedPhrase="xxx"`