### PR TITLE
fix: move x-api-key logic to middlewares

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -240,6 +240,7 @@ yargs // eslint-disable-line
     .middleware(require('../middleware/ledger'))
     .middleware(require('../middleware/abi'))
     .middleware(require('../middleware/seed-phrase'))
+    .middleware(require('../middleware/x-api-key'))
     .command(require('../commands/create-account').createAccountCommand)
     .command(require('../commands/create-account').createAccountCommandDeprecated)
     .command(viewAccount)

--- a/config.js
+++ b/config.js
@@ -1,5 +1,3 @@
-const { getXApiKey } = require('./utils/x-api-key-settings.js');
-
 const CONTRACT_NAME = process.env.CONTRACT_NAME;
 
 function getConfig(env) {
@@ -85,12 +83,6 @@ function getConfig(env) {
         break;
     default:
         throw Error(`Unconfigured environment '${env}'. Can be configured in src/config.js.`);
-    }
-
-    // adding x-api-key for given RPC Server
-    const apiKey = getXApiKey(config.nodeUrl);
-    if (apiKey) {
-        config.headers = { 'x-api-key': apiKey };
     }
     return config;
 }

--- a/middleware/x-api-key.js
+++ b/middleware/x-api-key.js
@@ -1,0 +1,9 @@
+const { getXApiKey } = require('../utils/x-api-key-settings');
+
+module.exports = async function setNodeXApiKey(options) {
+    const apiKey = getXApiKey(options.nodeUrl);
+    if (apiKey) {
+        options.headers = { 'x-api-key': apiKey };
+    }
+    return options;
+};


### PR DESCRIPTION
fixes #1051
The current implementation of the Near CLI that sets the x-api-key value in the yargs config. This approach ignores the `nodeUrl` option passed to the commands. It makes it difficult to manage custom RPCs since the x-api-key is bound to the nodeUrl in the config.

The proposed solution sets the x-api-key value in a middleware instead of the config file. This middleware applies the actual nodeUrl value passed to the command.
