### PR TITLE
Error message for undefined network includes network name passed

### DIFF
--- a/utils/inspect-response.js
+++ b/utils/inspect-response.js
@@ -13,7 +13,12 @@ const checkForAccDoesNotExist = (error, options) => {
     // below is optional approach, but "alias" in command options is better
     // const accountId = (options.accountId)? options.accountId : options.contractName;
     const currentNetwork = config.helperAccount;
-    console.log(chalk`\n{bold.red Account {bold.white ${options.accountId}} is not found in {bold.white ${suffixesToNetworks[currentNetwork]}}\n}`);
+    if (currentNetwork in suffixesToNetworks)  {
+        console.log(chalk`\n{bold.red Account {bold.white ${options.accountId}} is not found in {bold.white ${suffixesToNetworks[currentNetwork]}}\n}`);
+    }
+    else {
+        console.log(chalk`\n{bold.red Account {bold.white ${options.accountId}} is not found in an undefined network: {bold.white ${currentNetwork}}\n}`);
+    }
     
     const accSuffix = String(options.accountId).match('[^.]*$')[0];
     const accNetwork = suffixesToNetworks[accSuffix];


### PR DESCRIPTION
Updated error message for undefined network to include the name of the network that was passed

Previously, I was unsure if my commands were calling from 'localnet' or 'testnet'. I kept getting errors that it was an undefined network. Turns out, following the tutorials for localnet would pass in the name 'node0'. I spent hours debugging the wrong issue as I did pass in the correct network name. Hopefully, this more detailed error message would be helpful for beginners to near-cli in future. 