### PR TITLE
Error message for undefined node directly includes network name

### DIFF
--- a/config.js
+++ b/config.js
@@ -62,7 +62,7 @@ function getConfig(env) {
     case 'local':
     case 'localnet':
         config = {
-            networkId: process.env.NEAR_CLI_LOCALNET_NETWORK_ID || 'local',
+            networkId: process.env.NEAR_CLI_LOCALNET_NETWORK_ID || 'localnet',
             nodeUrl: process.env.NEAR_CLI_LOCALNET_RPC_SERVER_URL || process.env.NEAR_NODE_URL || 'http://127.0.0.1:3030',
             keyPath: process.env.NEAR_CLI_LOCALNET_KEY_PATH || `${process.env.HOME}/.near/validator_key.json`,
             walletUrl: process.env.NEAR_WALLET_URL || 'http://localhost:4000/wallet',

--- a/utils/inspect-response.js
+++ b/utils/inspect-response.js
@@ -13,13 +13,7 @@ const checkForAccDoesNotExist = (error, options) => {
     // below is optional approach, but "alias" in command options is better
     // const accountId = (options.accountId)? options.accountId : options.contractName;
     const currentNetwork = config.helperAccount;
-    if (currentNetwork in suffixesToNetworks)  {
-        console.log(chalk`\n{bold.red Account {bold.white ${options.accountId}} is not found in {bold.white ${suffixesToNetworks[currentNetwork]}}\n}`);
-    }
-    else {
-        console.log(chalk`\n{bold.red Account {bold.white ${options.accountId}} is not found in an undefined network: {bold.white ${currentNetwork}}\n}`);
-    }
-    
+    console.log(chalk`\n{bold.red Account {bold.white ${options.accountId}} is not found in {bold.white ${config.networkId}}\n}`);
     const accSuffix = String(options.accountId).match('[^.]*$')[0];
     const accNetwork = suffixesToNetworks[accSuffix];
     if (currentNetwork != accSuffix && accNetwork) {


### PR DESCRIPTION
<h1> Problem </h1>
- Previously, I was a a new user to near-cli and was not sure if I was passing the network name correctly.
- Upon inspecting, it seems the existing error message does a redundant helperAccount to networkName matching for only a subset of networks.

<h1> Solution </h1>
- Update to directly use the network configurations that was set.
- Also, updated network name from local to localnet as that's what's written on our documentations.

<h1> Tests </h1>
<h2> Nonexistent network </h2>
soonnear@Chees-MacBook-Pro nearup % NEAR_ENV=localnet2 near state node45

/Users/soonnear/Github/modified-near/near-cli/config.js:85
        throw Error(`Unconfigured environment '${env}'. Can be configured in src/config.js.`);
        ^

Error: Unconfigured environment 'localnet2'. Can be configured in src/config.js.
    at getConfig (/Users/soonnear/Github/modified-near/near-cli/config.js:85:15)
    at getConfig (/Users/soonnear/Github/modified-near/near-cli/get-config.js:14:54)
    at Object.<anonymous> (/Users/soonnear/Github/modified-near/near-cli/utils/inspect-response.js:2:40)
    at Module._compile (node:internal/modules/cjs/loader:1275:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1329:10)
    at Module.load (node:internal/modules/cjs/loader:1133:32)
    at Module._load (node:internal/modules/cjs/loader:972:12)
    at Module.require (node:internal/modules/cjs/loader:1157:19)
    at require (node:internal/modules/helpers:119:18)
    at object.<anonymous> (/users/soonnear/github/modified-near/near-cli/index.js:16:25)
node.js v19.8.1

<h2> Nonexistent node </h2>
soonnear@Chees-MacBook-Pro nearup % NEAR_ENV=localnet near state node45

Loaded master account test.near key from /Users/soonnear/.near/validator_key.json with public key = redacted Account node45 is not found in localnet

<h2> Proer usage </h2>
soonnear@Chees-MacBook-Pro nearup % NEAR_ENV=localnet near state node1

Loaded master account test.near key from /Users/soonnear/.near/validator_key.json with public key = redacted Account node1
{
  amount: '950000000000000000000000000000000',
  block_hash: '46Vc4CVx7giRpEKSQL3ywrr7dFe1vrZTzwBnPMXYY9as',
  block_height: 0,
  code_hash: '11111111111111111111111111111111',
  locked: '50000000000000000000000000000000',
  storage_paid_at: 0,
  storage_usage: 182,
  formattedAmount: '950,000,000'
}