### PR TITLE
Change default wallet

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,7 +9,7 @@ function getConfig(env) {
             networkId: 'mainnet',
             nodeUrl: process.env.NEAR_CLI_MAINNET_RPC_SERVER_URL || 'https://rpc.mainnet.near.org',
             contractName: CONTRACT_NAME,
-            walletUrl: 'https://wallet.near.org',
+            walletUrl: 'https://app.mynearwallet.com',
             helperUrl: 'https://helper.mainnet.near.org',
             helperAccount: 'near',
             explorerUrl: 'https://explorer.mainnet.near.org',


### PR DESCRIPTION
`near-cli` currently uses wallet.near.org, which will be soon deprecated, we should move it to `mynearwallet` which has the same interface, making the change transparent