### PR TITLE
(Minor) Remove phrase in delete account message

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const checkExistingContract = async function(prevCodeHash) {
 
 const confirmDelete = function () {
     return askYesNoQuestion(
-        chalk`{bold.white This method will delete your account. Beneficiary account must already be initialized in order to transfer all Near tokens or these will be lost. Make sure to send all fungible tokens or NFTs that you own to the beneficiary account prior to deleting, as this method will only transfer NEAR tokens. Do you want to proceed? {bold.green (y/n) }}`,
+        chalk`{bold.white This method will delete your account. Beneficiary account must already be initialized in order to transfer all Near tokens. Make sure to send all fungible tokens or NFTs that you own to the beneficiary account prior to deleting, as this method will only transfer NEAR tokens. Do you want to proceed? {bold.green (y/n) }}`,
         false);
 };
 


### PR DESCRIPTION
This reverts commit 76b2742ee7fb0f0f690dd0110e3e70dd2a5444a0.

When I go to delete an account and give the remaining tokens to a beneficiary, it gives a warning that is not correct, and might be concerning to new developers.

It says, "Beneficiary account must already be initialized in order to transfer all Near tokens **or these will be lost**."

In truth, if the beneficiary account hasn't been set up on yet, NEAR CLI will not proceed. See this screenshot, where I am attempting to delete `delme.mike.testnet` and give it a non-existent account name:

![Screenshot 2024-01-22 at 4 07 18 PM](https://github.com/near/near-cli/assets/1042667/4587e388-4cc7-471c-9813-82c257aaf09f)

Minor stuff, just trying to make sure the wording doesn't cause undue concern for new builders, as they shouldn't worry about losing funds after all.