### PR TITLE
Exit with error on error

### DIFF
--- a/commands/contract/call.js
+++ b/commands/contract/call.js
@@ -85,10 +85,11 @@ async function scheduleFunctionCall(options) {
         case '{"ExecutionError":"Exceeded the prepaid gas."}': {
             console.log(chalk(`\nTransaction ${error.transaction_outcome.id} had ${options.gas} of attached gas but used ${error.transaction_outcome.outcome.gas_burnt} of gas`));
             console.log('View this transaction in explorer:', chalk.blue(`https://explorer.${options.networkId}.near.org/transactions/${error.transaction_outcome.id}`));
+            process.exit(1);
             break;
         }
         default: {
-            console.log(error);
+            throw error;
         }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-cli",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "description": "Simple CLI for interacting with NEAR Protocol",
   "engines": {
     "node": ">= 16"

--- a/test/test_account_operations.sh
+++ b/test/test_account_operations.sh
@@ -8,7 +8,7 @@ testaccount=testaccount$timestamp$RANDOM.testnet
 
 echo Get account state
 RESULT=$(./bin/near state $testaccount)
-EXPECTED="Account $testaccount.+amount:.+'5000001000000000000000000'.+ "
+EXPECTED="Account $testaccount.+amount:.+'10000001000000000000000000'.+ "
 if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     echo FAILURE Unexpected output from near view
     echo Got: $RESULT


### PR DESCRIPTION
Currently `near call` will exit with code 0 even if an error happened. This PR fixes it so, on error, `near call` exits with code 1