### PR TITLE
fix: implicit account shows correctly

### DIFF
--- a/commands/credentials/generate.js
+++ b/commands/credentials/generate.js
@@ -33,7 +33,7 @@ module.exports = {
 };
 
 function pKtoAccountId(publicKey) {
-    return decode(publicKey.replace('ed25519:', '')).toString('hex');
+    return Buffer.from(decode(publicKey.replace('ed25519:', ''))).toString('hex');
 }
 
 async function generateKey(options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-cli",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Simple CLI for interacting with NEAR Protocol",
   "engines": {
     "node": ">= 16"


### PR DESCRIPTION
The command `generate-key` was displaying a `[u8;32]` array instead of a String. This is:

```bash
Implicit account: 118,91,39,254,....
```

instead of

```bash
Implicit account: 528dfe27ee6e6aa4a715f4ffacb4166b31d9c7b2ea741ab1b2b905363b4eec28
```
