### PR TITLE
feat: Add detailed instructions for installing near-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ _Click on a command for more information and examples._
 npm install -g near-cli
 ```
 
+For example, on Ubuntu 20.04 `near-cli` can be installed by running:
+```bash
+# Install nvm (https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.bashrc
+
+# Install node
+nvm install node
+
+# Install near-cli
+npm install -g near-cli
+
+# near-cli works!
+near --help
+```
+
 #### Windows
 
 > For Windows users, we recommend using Windows Subsystem for Linux (`WSL`).


### PR DESCRIPTION
The installation guide in `README.md` provides a brief explanation of how to install the tool, but it isn't as detailed as it could be. For someone who isn't familiar with the javascript ecosystem the whole thing is pretty confusing - why `nvm`? Can I just do `apt install npm`? Why not? It took me some time before I found a sequence of instructions that worked.
[And users also run into problems](https://near.zulipchat.com/#narrow/stream/422293-pagoda.2Fcore.2Fstake-wars-iv/topic/questions.20and.20feedback/near/421267934)

It would be great to have a detailed step-by-step instruction on how to install `near-cli`. So this PR adds the exact list of steps needed to install `near-cli` on Ubuntu 20.04 LTS.