### PR TITLE
fix: bring back ledger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ _Click on a command for more information and examples._
 | [`near tx-status`](#near-tx-status)             | queries a transaction's status by `txHash`                                                |
 
 
-[ [**OPTIONS**](#options) ]
-
-> For EVM support see [Project Aurora's](https://aurora.dev) [`aurora-cli`](https://github.com/aurora-is-near/aurora-cli).
-
 ---
 
 ## Setup
@@ -100,7 +96,7 @@ npm install -g near-cli
 - You can change the network by prepending an environment variable to your command.
 
 ```bash
-NEAR_NETWORK=betanet near send ...
+NEAR_NETWORK=testnet near send ...
 ```
 
 - Alternatively, you can set up a global environment variable by running:
@@ -161,6 +157,8 @@ near add-credentials example-acct.testnet --seedPhrase "antique attitude say evo
 ### `near add-key`
 
 > Adds either a **full access** or **function access** key to a given account.
+
+> Optionally allows to sign with a Ledger: `--signWithLedger` `--ledgerPath`
 
 **Note:** You will use an _existing_ full access key for the account you would like to add a _new_ key to. ([`near login`](http://docs.near.org/docs/tools/near-cli#near-login))
 
@@ -224,6 +222,7 @@ near add-key example-acct.testnet GkMNfc92fwM1AmwH1MTjF4b7UZuceamsq96XPkHsQ9vi -
 ### `near delete-key`
 
 > Deletes an existing key for a given account.
+> Optionally allows to sign with a Ledger: `--signWithLedger` `--ledgerPath`
 
 -   arguments: `accountId` `publicKey`
 -   options: `--networkId`, `force`
@@ -253,7 +252,7 @@ near delete-key example-acct.testnet Cxg2wgFYrdLTEkMu6j5D6aEZqTb3kXbmJygS48ZKbo1
 > Displays a key-pair and seed-phrase and optionally stores it locally in `.near-credentials`.
 
 -   arguments: `accountId` or `none`
--   options: `--fromSeedPhrase`, `--saveImplicit`
+-   options: `--fromSeedPhrase`, `--saveImplicit`, `--queryLedgerPK`
 
 **Note:** There are several ways to use `generate-key` that return very different results. Please reference the examples below for further details.
 
@@ -361,6 +360,78 @@ Implicit account: 9c07afc7673ea0f9a20c8a279e8bbe1dd1e283254263bb3b07403e4b6fd7a4
 
 Will store the key pair corresponding to the seedPhrase in `.near-credentials` with an `accountId` that you specify.
 
+<details>
+<summary><strong>Example Response</strong></summary>
+<p>
+
+```
+Seed phrase: antique attitude say evolve ring arrive hollow auto wide bronze usual unfold
+Key pair: {"publicKey":"ed25519:BW5Q957u1rTATGpanKUktjVmixEmT56Df4Dt9hoGWEXz","secretKey":"ed25519:5StmPDg9xVNzpyudwxT8Y72iyRq7Fa86hcpsRk6Cq5eWGWqwsPbPT9woXbJs9Qe69crZJHh4DMkrGEPGDDfmXmy2"}
+Implicit account: 9c07afc7673ea0f9a20c8a279e8bbe1dd1e283254263bb3b07403e4b6fd7a411
+```
+
+</p>
+</details>
+
+---
+
+#### 4a) `near generate-key --queryLedgerPK`
+
+> Uses a connected Ledger device to display a public key and [implicit account](http://docs.near.org/docs/roles/integrator/implicit-accounts) using the default HD path (`"44'/397'/0'/0'/1'"`)
+
+```bash
+near generate-key --queryLedgerPK
+```
+
+You should then see the following prompt to confirm this request on your Ledger device:
+
+  Make sure to connect your Ledger and open NEAR app
+  Getting Public Key from Ledger...
+
+After confirming the request on your Ledger device, a public key and implicit accountId will be displayed.
+
+<details>
+<summary><strong>Example Response</strong></summary>
+<p>
+
+```bash
+Using public key: ed25519:B22RP10g695wyeRvKIWv61NjmQZEkWTMzAYgdfx6oSeB2
+Implicit account: 42c320xc20739fd9a6bqf2f89z61rd14efe5d3de234199bc771235a4bb8b0e1
+```
+
+</p>
+</details>
+
+---
+
+#### 3b) `near generate-key --queryLedgerPK --ledgerPath="HD path you specify"`
+
+> Uses a connected Ledger device to display a public key and [implicit account](http://docs.near.org/docs/roles/integrator/implicit-accounts) using a custom HD path.
+
+```bash
+near generate-key --queryLedgerPK --ledgerPath="44'/397'/0'/0'/2'"
+```
+
+You should then see the following prompt to confirm this request on your Ledger device:
+
+    Make sure to connect your Ledger and open NEAR app
+    Waiting for confirmation on Ledger...
+
+After confirming the request on your Ledger device, a public key and implicit accountId will be displayed.
+
+<details>
+<summary><strong>Example Response</strong></summary>
+<p>
+
+```bash
+Using public key: ed25519:B22RP10g695wye3dfa32rDjmQZEkWTMzAYgCX6oSeB2
+Implicit account: 42c320xc20739ASD9a6bqf2Dsaf289z61rd14efe5d3de23213789009afDsd5bb8b0e1
+```
+
+</p>
+</details>
+
+
 ---
 
 ### `near list-keys`
@@ -439,7 +510,7 @@ near login
 > Creates an account using an existing account or a faucet service to pay for the account's creation and initial balance.
 
 -   arguments: `accountId`
--   options: `--initialBalance`, `--useFaucet`, `--useAccount`
+-   options: `--initialBalance`, `--useFaucet`, `--useAccount`, `--signWithLedger`, `--ledgerPath`, `--useLedgerPK`, `--PkLedgerPath`
 
 **Examples:**:
 
@@ -453,10 +524,26 @@ near create-account new-acc.testnet --useAccount example-acct.testnet
 near create-account new-acc.testnet --useFaucet
 ```
 
+```bash
+# Creating a pre-funded account that can be controlled by the Ledger's public key
+near create-account new-acc.testnet --useFaucet --useLedgerPK 
+```
+
+```bash
+# Creating an account using a Ledger account
+near create-account new-acc.testnet --useAccount ledger-acct.testnet --signWithLedger
+```
+
 **Subaccount example:**
 
 ```bash
+# Using an account to create a sub-account
 near create-account sub-acct.example-acct.testnet --useAccount example-acct.testnet
+```
+
+```bash
+# Creating a sub-account using the Ledger that can also be controlled by the ledger
+near create-account sub.acc.testnet --useAccount sub.acc.testnet --signWithLedger --useLedgerPK
 ```
 
 **Example using `--initialBalance`:**
@@ -482,7 +569,7 @@ near create-account sub-acct2.example-acct.testnet --useAccount example-acct.tes
 > Deletes an account and transfers remaining balance to a beneficiary account.
 
 -   arguments: `accountId` `beneficiaryId`
--   options: `force`
+-   options: `force`, `--signWithLedger`, `--ledgerPath`
 
 **Example:**
 
@@ -510,7 +597,8 @@ near delete-account sub-acct2.example-acct.testnet example-acct.testnet
 
 > Sends NEAR tokens (Ⓝ) from one account to another.
 
--   arguments: `senderId` `receiverId` `amount`
+- arguments: `senderId` `receiverId` `amount`
+- options: `--signWithLedger`, `--ledgerPath`
 
 **Note:** You will need a full access key for the sending account. ([`near login`](http://docs.near.org/docs/tools/near-cli#near-login))
 
@@ -577,7 +665,7 @@ near state example.testnet
 **Note:** Contract calls require a transaction fee (gas) so you will need an access key for the `--accountId` that will be charged. ([`near login`](http://docs.near.org/docs/tools/near-cli#near-login))
 
 -   arguments: `contractName` `method_name` `{ args }` `--accountId`
--   options: `--gas` `--deposit`
+-   options: `--gas` `--deposit` `--signWithLedger` `--ledgerPath`
 
 **Example:**
 
@@ -612,13 +700,13 @@ near call guest-book.testnet addMessage '{"text": "Aloha"}' --account-id example
 **Example:**
 
 ```bash
-near deploy --accountId example-contract.testnet --wasmFile out/example.wasm
+near deploy example-contract.testnet out/example.wasm
 ```
 
 **Initialize Example:**
 
 ```bash
-near deploy --accountId example-contract.testnet --wasmFile out/example.wasm --initFunction new --initArgs '{"owner_id": "example-contract.testnet", "total_supply": "10000000"}'
+near deploy example-contract.testnet out/example.wasm --initFunction new --initArgs '{"owner_id": "example-contract.testnet", "total_supply": "10000000"}'
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ near login
 > Creates an account using an existing account or a faucet service to pay for the account's creation and initial balance.
 
 -   arguments: `accountId`
--   options: `--initialBalance`, `--useFaucet`, `--useAccount`, `--signWithLedger`, `--ledgerPath`, `--useLedgerPK`, `--PkLedgerPath`
+-   options: `--initialBalance`, `--useFaucet`, `--useAccount`, `--seedPhrase`, `--publicKey`, `--signWithLedger`, `--ledgerPath`, `--useLedgerPK`, `--PkLedgerPath`
 
 **Examples:**:
 

--- a/bin/near
+++ b/bin/near
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const flaggedRespawn = require('flagged-respawn');
+
 require('v8flags')((e, flags) => {
     if (e) {
         throw e;
@@ -14,4 +15,4 @@ require('v8flags')((e, flags) => {
                 require('./near-cli.js');
             }
         });
-})
+});

--- a/commands/account/create.js
+++ b/commands/account/create.js
@@ -6,6 +6,7 @@ const { assertCredentials, storeCredentials } = require('../../utils/credentials
 const { DEFAULT_NETWORK } = require('../../config');
 const chalk = require('chalk');
 const { getPublicKeyForPath } = require('../../utils/ledger');
+const { parseSeedPhrase } = require('near-seed-phrase');
 
 module.exports = {
     command: 'create-account <new-account-id>',
@@ -31,6 +32,11 @@ module.exports = {
         })
         .option('publicKey', {
             desc: 'Public key to initialize the account with',
+            type: 'string',
+            required: false
+        })
+        .option('seedPhrase', {
+            desc: 'seedPhrase from which to derive the account\'s publicKey',
             type: 'string',
             required: false
         })
@@ -104,6 +110,12 @@ async function create(options) {
 
     let keyPair;
     let publicKey = options.useLedgerPK ? await getPublicKeyForPath(options.PkLedgerPath) : options.publicKey;
+
+    if (options.seedPhrase) {
+        const parsed = parseSeedPhrase(options.seedPhrase);
+        keyPair = KeyPair.fromString(parsed.secretKey);
+        publicKey = keyPair.getPublicKey();
+    }
 
     if (!publicKey) {
         // If no public key is specified, create a random one

--- a/commands/account/delete.js
+++ b/commands/account/delete.js
@@ -41,7 +41,7 @@ const confirmDelete = function (accountId, beneficiaryId) {
 };
 
 async function deleteAccount(options) {
-    await assertCredentials(options);
+    await assertCredentials(options.accountId, options.networkId, options.keyStore, options.useLedgerKey);
     const near = await connect(options);
     const beneficiaryAccount = await near.account(options.beneficiaryId);
 

--- a/commands/account/delete.js
+++ b/commands/account/delete.js
@@ -10,6 +10,17 @@ module.exports = {
     aliases: ['delete'],
     desc: 'Delete account, sending remaining NEAR to a beneficiary',
     builder: (yargs) => yargs
+        .option('signWithLedger', {
+            alias: ['useLedgerKey'],
+            desc: 'Use Ledger for signing',
+            type: 'boolean',
+            default: false
+        })
+        .option('ledgerPath', {
+            desc: 'HD key path',
+            type: 'string',
+            default: "44'/397'/0'/0'/1'"
+        })
         .option('networkId', {
             desc: 'Which network to use. Supports: mainnet, testnet, custom',
             type: 'string',
@@ -30,7 +41,7 @@ const confirmDelete = function (accountId, beneficiaryId) {
 };
 
 async function deleteAccount(options) {
-    await assertCredentials(options.accountId, options.networkId, options.keyStore);
+    await assertCredentials(options);
     const near = await connect(options);
     const beneficiaryAccount = await near.account(options.beneficiaryId);
 

--- a/commands/contract/call.js
+++ b/commands/contract/call.js
@@ -69,7 +69,7 @@ async function scheduleFunctionCall(options) {
         options.keyStore.setKey(options.networkId, options.accountId, keyPair);
     }
 
-    await assertCredentials(options);
+    await assertCredentials(options.accountId, options.networkId, options.keyStore, options.useLedgerKey);
 
     const deposit = options.depositYocto != null ? options.depositYocto : utils.format.parseNearAmount(options.deposit);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +

--- a/commands/contract/call.js
+++ b/commands/contract/call.js
@@ -16,6 +16,17 @@ module.exports = {
             desc: 'Account that will execute the actions',
             type: 'string'
         })
+        .option('signWithLedger', {
+            alias: ['useLedgerKey'],
+            desc: 'Use Ledger for signing',
+            type: 'boolean',
+            default: false
+        })
+        .option('ledgerPath', {
+            desc: 'HD key path',
+            type: 'string',
+            default: "44'/397'/0'/0'/1'"
+        })
         .option('networkId', {
             desc: 'Which network to use. Supports: mainnet, testnet, custom',
             type: 'string',
@@ -58,7 +69,7 @@ async function scheduleFunctionCall(options) {
         options.keyStore.setKey(options.networkId, options.accountId, keyPair);
     }
 
-    await assertCredentials(options.accountId, options.networkId, options.keyStore);
+    await assertCredentials(options);
 
     const deposit = options.depositYocto != null ? options.depositYocto : utils.format.parseNearAmount(options.deposit);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +

--- a/commands/contract/deploy.js
+++ b/commands/contract/deploy.js
@@ -47,7 +47,7 @@ module.exports = {
     handler: deploy
 };
 
-const checkExistingContract = async function (prevCodeHash) {
+const askOverrideContract = async function (prevCodeHash) {
     if (prevCodeHash !== '11111111111111111111111111111111') {
         return await askYesNoQuestion(
             chalk`{bold.white This account already has a deployed contract [ {bold.blue ${prevCodeHash}} ]. Do you want to proceed? {bold.green (y/n) }}`,
@@ -65,8 +65,7 @@ async function deploy(options) {
     let prevState = await account.state();
     let prevCodeHash = prevState.code_hash;
 
-    const answeredYes = await checkExistingContract(prevCodeHash);
-    if (!options.force && !answeredYes) return;
+    if(!options.force && !(await askOverrideContract(prevCodeHash))) return;
 
     console.log(`Deploying contract ${options.wasmFile} in ${options.accountId}`);
 

--- a/commands/contract/deploy.js
+++ b/commands/contract/deploy.js
@@ -58,7 +58,7 @@ const checkExistingContract = async function (prevCodeHash) {
 };
 
 async function deploy(options) {
-    await assertCredentials(options);
+    await assertCredentials(options.accountId, options.networkId, options.keyStore, options.useLedgerKey);
 
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/contract/deploy.js
+++ b/commands/contract/deploy.js
@@ -58,7 +58,7 @@ const checkExistingContract = async function (prevCodeHash) {
 };
 
 async function deploy(options) {
-    await assertCredentials(options.accountId, options.networkId, options.keyStore);
+    await assertCredentials(options);
 
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/credentials/generate.js
+++ b/commands/credentials/generate.js
@@ -19,6 +19,17 @@ module.exports = {
             type: 'boolean',
             default: false
         })
+        .option('queryLedgerPK', {
+            alias: ['useLedgerKey'],
+            desc: 'Save the key as credentials for the implicit account',
+            type: 'boolean',
+            default: false
+        })
+        .option('ledgerPath', {
+            desc: 'Path to the Ledger key',
+            type: 'string',
+            default: "44'/397'/0'/0'/1'"
+        })
         .option('networkId', {
             desc: 'Which network to use. Supports: mainnet, testnet, custom',
             type: 'string',
@@ -38,6 +49,14 @@ function pKtoAccountId(publicKey) {
 
 async function generateKey(options) {
     let secret;
+
+    if (options.queryLedgerPK) {
+        const { getPublicKeyForPath } = require('../../utils/ledger');
+        const publicKey = await getPublicKeyForPath(options.ledgerPath);
+        console.log(`Public key: ${publicKey}`);
+        console.log(`Implicit account: ${pKtoAccountId(publicKey.toString())}`);
+        return;
+    }
 
     if (options.fromSeedPhrase) {
         const { publicKey, secretKey } = parseSeedPhrase(options.fromSeedPhrase);

--- a/commands/keys/add.js
+++ b/commands/keys/add.js
@@ -24,6 +24,17 @@ module.exports = {
             required: false,
             default: '0'
         })
+        .option('signWithLedger', {
+            alias: ['useLedgerKey'],
+            desc: 'Use Ledger for signing',
+            type: 'boolean',
+            default: false
+        })
+        .option('ledgerPath', {
+            desc: 'HD key path',
+            type: 'string',
+            default: "44'/397'/0'/0'/1'"
+        })
         .option('networkId', {
             desc: 'Which network to use. Supports: mainnet, testnet, custom',
             type: 'string',
@@ -33,7 +44,7 @@ module.exports = {
 };
 
 async function addAccessKey(options) {
-    await assertCredentials(options.accountId, options.networkId, options.keyStore);
+    await assertCredentials(options);
 
     console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key ${options.publicKey} to ${options.accountId}.`);
     if (options.contractId) console.log(`Limited to: ${options.allowance} $NEAR and methods: ${options.methodNames.join(' ')}.`);

--- a/commands/keys/add.js
+++ b/commands/keys/add.js
@@ -44,7 +44,7 @@ module.exports = {
 };
 
 async function addAccessKey(options) {
-    await assertCredentials(options);
+    await assertCredentials(options.accountId, options.networkId, options.keyStore, options.useLedgerKey);
 
     console.log(`Adding ${options.contractId ? 'function call access' : 'full access'} key ${options.publicKey} to ${options.accountId}.`);
     if (options.contractId) console.log(`Limited to: ${options.allowance} $NEAR and methods: ${options.methodNames.join(' ')}.`);

--- a/commands/keys/delete.js
+++ b/commands/keys/delete.js
@@ -9,6 +9,17 @@ module.exports = {
     command: 'delete-key <account-id> <access-key>',
     desc: 'Delete access key',
     builder: (yargs) => yargs
+        .option('signWithLedger', {
+            alias: ['useLedgerKey'],
+            desc: 'Use Ledger for signing',
+            type: 'boolean',
+            default: false
+        })
+        .option('ledgerPath', {
+            desc: 'HD key path',
+            type: 'string',
+            default: "44'/397'/0'/0'/1'"
+        })
         .option('networkId', {
             desc: 'Which network to use. Supports: mainnet, testnet, custom',
             type: 'string',
@@ -23,7 +34,7 @@ module.exports = {
 };
 
 async function deleteAccessKey(options) {
-    await assertCredentials(options.accountId, options.networkId, options.keyStore);
+    await assertCredentials(options);
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const approval = await isAllApprovalsGranted(account, options.accessKey);

--- a/commands/keys/delete.js
+++ b/commands/keys/delete.js
@@ -34,7 +34,7 @@ module.exports = {
 };
 
 async function deleteAccessKey(options) {
-    await assertCredentials(options);
+    await assertCredentials(options.accountId, options.networkId, options.keyStore, options.useLedgerKey);
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const approval = await isAllApprovalsGranted(account, options.accessKey);

--- a/commands/transactions/send.js
+++ b/commands/transactions/send.js
@@ -14,6 +14,17 @@ module.exports = {
             desc: 'Amount of NEAR tokens to send',
             type: 'string',
         })
+        .option('signWithLedger', {
+            alias: ['useLedgerKey'],
+            desc: 'Use Ledger for signing',
+            type: 'boolean',
+            default: false
+        })
+        .option('ledgerPath', {
+            desc: 'HD key path',
+            type: 'string',
+            default: "44'/397'/0'/0'/1'"
+        })
         .option('networkId', {
             desc: 'Which network to use. Supports: mainnet, testnet, custom',
             type: 'string',
@@ -23,10 +34,11 @@ module.exports = {
 };
 
 async function sendMoney(options) {
-    await assertCredentials(options.sender, options.networkId, options.keyStore);
+    await assertCredentials(options);
 
     const near = await connect(options);
     const account = await near.account(options.sender);
+
     try {
         console.log(`Sending ${options.amount} NEAR to ${options.receiver} from ${options.sender}`);
         const result = await account.sendMoney(options.receiver, utils.format.parseNearAmount(options.amount));

--- a/commands/transactions/send.js
+++ b/commands/transactions/send.js
@@ -34,7 +34,7 @@ module.exports = {
 };
 
 async function sendMoney(options) {
-    await assertCredentials(options);
+    await assertCredentials(options.sender, options.networkId, options.keyStore, options.useLedgerKey);
 
     const near = await connect(options);
     const account = await near.account(options.sender);

--- a/commands/validators/stake.js
+++ b/commands/validators/stake.js
@@ -26,6 +26,17 @@ module.exports = {
             type: 'string',
             required: true,
         })
+        .option('signWithLedger', {
+            alias: ['useLedgerKey'],
+            desc: 'Use Ledger for signing',
+            type: 'boolean',
+            default: false
+        })
+        .option('ledgerPath', {
+            desc: 'HD key path',
+            type: 'string',
+            default: "44'/397'/0'/0'/1'"
+        })
         .option('networkId', {
             desc: 'Which network to use. Supports: mainnet, testnet, custom',
             type: 'string',
@@ -36,7 +47,7 @@ module.exports = {
 
 
 async function stake(options) {
-    await assertCredentials(options.accountId, options.networkId, options.keyStore);
+    await assertCredentials(options);
     console.log(`Staking ${options.amount} (${utils.format.parseNearAmount(options.amount)}N) on ${options.accountId} with public key = ${qs.unescape(options.stakingKey)}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/commands/validators/stake.js
+++ b/commands/validators/stake.js
@@ -47,7 +47,7 @@ module.exports = {
 
 
 async function stake(options) {
-    await assertCredentials(options);
+    await assertCredentials(options.accountId, options.networkId, options.keyStore, options.useLedgerKey);
     console.log(`Staking ${options.amount} (${utils.format.parseNearAmount(options.amount)}N) on ${options.accountId} with public key = ${qs.unescape(options.stakingKey)}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);

--- a/ledger-test.sh
+++ b/ledger-test.sh
@@ -1,0 +1,24 @@
+# CREATE WITH FAUCET
+yarn start create-account miralos-como-sonrien.testnet --ledgerPK --useFaucet
+
+# CREATE WITH ACCOUNT
+yarn start create-account ya.miralos-como-sonrien.testnet --ledgerPK --useAccount miralos-como-sonrien.testnet --useLedgerKey
+
+# SEND-NEAR
+yarn start send-near miralos-como-sonrien.testnet influencer.testnet 0.01 --useLedgerKey
+
+# CALL
+yarn start call hello.near-examples.testnet set_greeting '{"greeting":"Hola"}' --accountId miralos-como-sonrien.testnet --useLedgerKey
+
+# DEPLOY
+yarn start deploy miralos-como-sonrien.testnet ./contract.wasm --signWithLedger
+
+## ADD KEY
+yarn start add-key miralos-como-sonrien.testnet ed25519:GnsdHdSrhe8v3MMAQi2bnXR59xMDwdkSRAFZ961ydxWZ --signWithLedger
+
+## DELETE KEY
+yarn start delete-key miralos-como-sonrien.testnet ed25519:GnsdHdSrhe8v3MMAQi2bnXR59xMDwdkSRAFZ961ydxWZ --signWithLedger
+
+## DELETE
+yarn start delete miralos-como-sonrien.testnet influencer.testnet --useLedgerKey
+yarn start delete ya.miralos-como-sonrien.testnet influencer.testnet --signWithLedger

--- a/ledger-test.sh
+++ b/ledger-test.sh
@@ -1,17 +1,18 @@
 # CREATE WITH FAUCET
-yarn start create-account miralos-como-sonrien.testnet --ledgerPK --useFaucet
+yarn start create-account miralos-como-sonrien.testnet --useLedgerPK --useFaucet
 
 # CREATE WITH ACCOUNT
-yarn start create-account ya.miralos-como-sonrien.testnet --ledgerPK --useAccount miralos-como-sonrien.testnet --useLedgerKey
+yarn start create-account ya.miralos-como-sonrien.testnet --useLedgerPK --useAccount miralos-como-sonrien.testnet --useLedgerKey
 
 # SEND-NEAR
 yarn start send-near miralos-como-sonrien.testnet influencer.testnet 0.01 --useLedgerKey
+yarn start send-near ya.miralos-como-sonrien.testnet influencer.testnet 0.01 --useLedgerKey
 
 # CALL
 yarn start call hello.near-examples.testnet set_greeting '{"greeting":"Hola"}' --accountId miralos-como-sonrien.testnet --useLedgerKey
 
-# DEPLOY
-yarn start deploy miralos-como-sonrien.testnet ./contract.wasm --signWithLedger
+# DEPLOY (not available yet, maybe in the future with the Ledger App update?)
+# yarn start deploy miralos-como-sonrien.testnet ./contract.wasm --signWithLedger
 
 ## ADD KEY
 yarn start add-key miralos-como-sonrien.testnet ed25519:GnsdHdSrhe8v3MMAQi2bnXR59xMDwdkSRAFZ961ydxWZ --signWithLedger

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-cli",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Simple CLI for interacting with NEAR Protocol",
   "engines": {
     "node": ">= 16"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-cli",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "Simple CLI for interacting with NEAR Protocol",
   "engines": {
     "node": ">= 16"

--- a/package.json
+++ b/package.json
@@ -36,12 +36,14 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@ledgerhq/hw-transport-node-hid": "^6.28.4",
     "ascii-table": "^0.0.9",
     "bs58": "^5.0.0",
     "chalk": "^4.1.2",
     "flagged-respawn": "^2.0.0",
     "is-ci": "^3.0.1",
     "near-api-js": "^3.0.2",
+    "near-ledger-js": "^0.2.1",
     "near-seed-phrase": "^0.2.0",
     "open": "^8.4.2",
     "stoppable": "^1.1.0",

--- a/test/test_account_creation.sh
+++ b/test/test_account_creation.sh
@@ -6,6 +6,7 @@ testaccount1=test-ac-${timestamp}-1.testnet
 testaccount2=test-ac-${timestamp}-2.testnet
 testaccount3=test-ac-${timestamp}-3.testnet
 testaccount4=test-ac-${timestamp}-4.testnet
+testaccount5=test-ac-${timestamp}-5.testnet
 zerobalance=test-ac-${timestamp}-z.testnet
 withbalance=test-ac-${timestamp}-y.testnet
 
@@ -13,6 +14,19 @@ tla=${timestamp}${timestamp}${timestamp}12
 
 # Can create a pre-funded account
 ./bin/near create-account $testaccount1 --useFaucet
+
+# Can create a pre-funded account with a seedPhrase
+./bin/near create-account $testaccount5 --useFaucet --seedPhrase "crisp clump stay mean dynamic become fashion mail bike disorder chronic sight"
+
+RESULT=$(./bin/near list-keys $testaccount5)
+EXPECTED=".*GPnL8k4MV1hLccB5rkNiihVAEEmQX3BTDJnmW1T7ZDXG.*"
+if [[ ! "$RESULT" =~ $EXPECTED ]]; then
+    echo FAILURE Unexpected output from near list-keys
+    echo Got: $RESULT
+    echo Expected: $EXPECTED
+    exit 1
+fi
+
 
 # Can create an account with a given public key & balance
 ./bin/near create-account sub.$testaccount1 --accountId $testaccount1 --publicKey "78MziB9aTNsu19MHHVrfWy762S5mAqXgCB6Vgvrv9uGV"  --initialBalance 0.01

--- a/utils/connect.js
+++ b/utils/connect.js
@@ -1,7 +1,16 @@
 const { connect: nearConnect } = require('near-api-js');
 const { getConfig } = require('../config');
+const { getPublicKeyForPath, signForPath } = require('./ledger');
 
 module.exports = async function connect({ keyStore, ...options }) {
+    // If using Ledger, override the signer so that it uses the Ledger device
+    if (options.signWithLedger) { 
+        options.signer = {
+            getPublicKey: () => getPublicKeyForPath(options.ledgerPath),
+            signMessage: (m) => signForPath(m, options.ledgerPath)
+        };
+    }      
+
     // TODO: Avoid need to wrap in deps
     const config = getConfig(options.networkId);
     return await nearConnect({ ...options, ...config, deps: { keyStore } });

--- a/utils/credentials.js
+++ b/utils/credentials.js
@@ -1,8 +1,10 @@
 const chalk = require('chalk');
 
-async function assertCredentials(accountId, networkId, keyStore) {
+async function assertCredentials({ accountId, networkId, keyStore, signWithLedger }) {
+    if (signWithLedger) return;
+
     const key = await keyStore.getKey(networkId, accountId);
-    if(key) return;
+    if (key) return;
 
     console.error(chalk`You are trying to use the account {bold.white ${accountId}}, but do not have the credentials locally (network: {bold.white ${networkId}})`);
     process.exit(1);
@@ -10,15 +12,15 @@ async function assertCredentials(accountId, networkId, keyStore) {
 
 async function storeCredentials(accountId, networkId, keyStore, keyPair, force) {
     const key = await keyStore.getKey(networkId, accountId);
-    
-    if(key && !force){
+
+    if (key && !force) {
         console.log(chalk`The account {bold.white ${accountId}} already has local credentials (network: {bold.white ${networkId}})`);
         return;
     }
 
     console.log(chalk`Storing credentials for account: {bold.white ${accountId}} (network: {bold.white ${networkId}})`);
     console.log(`Saving key to '~/.near-credentials/${networkId}/${accountId}.json'`);
-    await keyStore.setKey(networkId, accountId, keyPair);    
+    await keyStore.setKey(networkId, accountId, keyPair);
 }
 
-module.exports = {assertCredentials, storeCredentials};
+module.exports = { assertCredentials, storeCredentials };

--- a/utils/credentials.js
+++ b/utils/credentials.js
@@ -1,7 +1,7 @@
 const chalk = require('chalk');
 
-async function assertCredentials({ accountId, networkId, keyStore, signWithLedger }) {
-    if (signWithLedger) return;
+async function assertCredentials(accountId, networkId, keyStore, usingLedger) {
+    if (usingLedger) return;
 
     const key = await keyStore.getKey(networkId, accountId);
     if (key) return;

--- a/utils/ledger.js
+++ b/utils/ledger.js
@@ -1,0 +1,61 @@
+/*
+For future maintainers: The way this middleware works is by returning a signer object
+that is later **INJECTED** into the `near` object during the `connect` call.
+
+This way, each time an `account` object is created, the signer inside points the `account`
+object points to the Ledger.
+*/
+const { exit } = require('process');
+const { createClient } = require('near-ledger-js');
+const { utils: { PublicKey, key_pair: { KeyType } } } = require('near-api-js');
+const { default: TransportNodeHid } = require('@ledgerhq/hw-transport-node-hid');
+
+let client;
+let transport;
+let cachedPublicKeys = {};
+
+async function getPublicKeyForPath(hdKeyPath) {
+    // cache keys to avoid confirming on Ledger multiple times
+    if (cachedPublicKeys[hdKeyPath]) return cachedPublicKeys[hdKeyPath];
+
+    transport = await TransportNodeHid.create();
+    client = await createClient(transport);
+
+    console.log('Getting Public Key from Ledger...');
+
+    try {
+        const rawPublicKey = await client.getPublicKey(hdKeyPath);
+        const publicKey = new PublicKey({ keyType: KeyType.ED25519, data: rawPublicKey });
+        cachedPublicKeys[hdKeyPath] = publicKey;
+        console.log('Using public key:', publicKey.toString());
+        return publicKey;
+    } catch (e) { handleLedgerError(e); }
+}
+
+async function signForPath(message, hdKeyPath) {
+    const publicKey = await getPublicKeyForPath(hdKeyPath);
+
+    console.log('Waiting for confirmation on Ledger...');
+
+    try {
+        const signature = await client.sign(message, hdKeyPath);
+        return { signature, publicKey };
+    } catch (e) { handleLedgerError(e); }
+}
+
+function handleLedgerError(e) {
+    switch (e.statusText) {
+    case 'CONDITIONS_OF_USE_NOT_SATISFIED':
+        console.log('Rejected from Ledger');
+        exit(1);
+        break;
+    case 'UNKNOWN_ERROR':
+        console.log(`Ledger returned an unknown error (${e.statusCode}). Check your Ledger and try again`);
+        exit(1);
+        break;
+    default:
+        throw e;
+    }
+}
+
+module.exports = { getPublicKeyForPath, signForPath };

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,6 +678,120 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@ledgerhq/devices@^5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.51.1.tgz#d741a4a5d8f17c2f9d282fd27147e6fe1999edb7"
+  integrity sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==
+  dependencies:
+    "@ledgerhq/errors" "^5.50.0"
+    "@ledgerhq/logs" "^5.50.0"
+    rxjs "6"
+    semver "^7.3.5"
+
+"@ledgerhq/devices@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-8.2.1.tgz#c59eec50bacd2f962e22c723a74600160d41fbd0"
+  integrity sha512-l/2I/Xzt7Z32OmGzoc/mUvaZivdn7Id/SO7hBTGpk7PtJTpBRxVAabP4GWEKCayGyOAcvTwoVxM0HMkNVfIzOQ==
+  dependencies:
+    "@ledgerhq/errors" "^6.16.2"
+    "@ledgerhq/logs" "^6.12.0"
+    rxjs "^7.8.1"
+    semver "^7.3.5"
+
+"@ledgerhq/errors@^5.34.0", "@ledgerhq/errors@^5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.50.0.tgz#e3a6834cb8c19346efca214c1af84ed28e69dad9"
+  integrity sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow==
+
+"@ledgerhq/errors@^6.16.2":
+  version "6.16.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-6.16.2.tgz#cf3939dc92ed0871aa7fdd45e6d13446a1eaeccd"
+  integrity sha512-jFpohaSW+p1Obp3NDT9QSByEtT3gtBZIjVNu8m25gnrH5zdtfPVlPwH6UiuS50s+2dHQyehV8hF+IfreKDWAZA==
+
+"@ledgerhq/hw-transport-node-hid-noevents@^6.29.4":
+  version "6.29.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-6.29.4.tgz#9fae3a47e61ebf39448b700bfa087c9f3a5df7e7"
+  integrity sha512-g19nEwES/SIG9z0Zah6Y2zf883JCT57HSlHgR5DRHPrNXIJbJRZV/UbHQo3az/wZ642WmzGqkPUdmYGDjQu4rg==
+  dependencies:
+    "@ledgerhq/devices" "^8.2.1"
+    "@ledgerhq/errors" "^6.16.2"
+    "@ledgerhq/hw-transport" "^6.30.4"
+    "@ledgerhq/logs" "^6.12.0"
+    node-hid "^2.1.2"
+
+"@ledgerhq/hw-transport-node-hid@^6.28.4":
+  version "6.28.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-6.28.4.tgz#c50f4126ebee93404ec286523fa51658fe9806bf"
+  integrity sha512-f6yQvZe4cwg6ibRn1YE9wWTdvpyT7FBIxxYHAd4RKm0l5/WFZS2G8CwdNJQwlOr89iBgGvEswWYh8EhUxM5QYA==
+  dependencies:
+    "@ledgerhq/devices" "^8.2.1"
+    "@ledgerhq/errors" "^6.16.2"
+    "@ledgerhq/hw-transport" "^6.30.4"
+    "@ledgerhq/hw-transport-node-hid-noevents" "^6.29.4"
+    "@ledgerhq/logs" "^6.12.0"
+    lodash "^4.17.21"
+    node-hid "^2.1.2"
+    usb "2.9.0"
+
+"@ledgerhq/hw-transport-u2f@^5.36.0-deprecated":
+  version "5.36.0-deprecated"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.36.0-deprecated.tgz#66e3ed399a117a1c0110871a055dd54f5fe707fd"
+  integrity sha512-T/+mGHIiUK/ZQATad6DMDmobCMZ1mVST952009jKzhaE1Et2Uy2secU+QhRkx3BfEAkvwa0zSRSYCL9d20Iqjg==
+  dependencies:
+    "@ledgerhq/errors" "^5.34.0"
+    "@ledgerhq/hw-transport" "^5.34.0"
+    "@ledgerhq/logs" "^5.30.0"
+    u2f-api "0.2.7"
+
+"@ledgerhq/hw-transport-webhid@^5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-5.51.1.tgz#2050d65ef4ce179e8f43cd7245b811d8f05fdcfc"
+  integrity sha512-w/2qSU0vwFY+D/4ucuYRViO7iS3Uuxmj9sI/Iiqkoiax9Xppb0/6H5m3ffKv6iPMmRYbgwCgXorqx4SLLSD8Kg==
+  dependencies:
+    "@ledgerhq/devices" "^5.51.1"
+    "@ledgerhq/errors" "^5.50.0"
+    "@ledgerhq/hw-transport" "^5.51.1"
+    "@ledgerhq/logs" "^5.50.0"
+
+"@ledgerhq/hw-transport-webusb@^5.53.1":
+  version "5.53.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-5.53.1.tgz#3df8c401417571e3bcacc378d8aca587214b05ae"
+  integrity sha512-A/f+xcrkIAZiJrvPpDvsrjxQX4cI2kbdiunQkwsYmOG3Bp4z89ZnsBiC7YBst4n2/g+QgTg0/KPVtODU5djooQ==
+  dependencies:
+    "@ledgerhq/devices" "^5.51.1"
+    "@ledgerhq/errors" "^5.50.0"
+    "@ledgerhq/hw-transport" "^5.51.1"
+    "@ledgerhq/logs" "^5.50.0"
+
+"@ledgerhq/hw-transport@^5.34.0", "@ledgerhq/hw-transport@^5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz#8dd14a8e58cbee4df0c29eaeef983a79f5f22578"
+  integrity sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==
+  dependencies:
+    "@ledgerhq/devices" "^5.51.1"
+    "@ledgerhq/errors" "^5.50.0"
+    events "^3.3.0"
+
+"@ledgerhq/hw-transport@^6.30.4":
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-6.30.4.tgz#05dee1e9cdec0e430594ecf7f5cf90c13721ad70"
+  integrity sha512-VBcVd7UG8HDrjWMoZI5rqBDz+PBxLHTIPZOGY/fdMoEUwaBbss0Z3MxuJanMyerlfaLqnBSVuL0blz7rOyagkw==
+  dependencies:
+    "@ledgerhq/devices" "^8.2.1"
+    "@ledgerhq/errors" "^6.16.2"
+    "@ledgerhq/logs" "^6.12.0"
+    events "^3.3.0"
+
+"@ledgerhq/logs@^5.30.0", "@ledgerhq/logs@^5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
+  integrity sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA==
+
+"@ledgerhq/logs@^6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.12.0.tgz#ad903528bf3687a44da435d7b2479d724d374f5d"
+  integrity sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA==
+
 "@near-js/accounts@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@near-js/accounts/-/accounts-1.0.2.tgz#5bcb6df9985ec451b35e8c2e22ad8113ef523692"
@@ -1109,6 +1223,11 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/w3c-web-usb@^1.0.6":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@types/w3c-web-usb/-/w3c-web-usb-1.0.10.tgz#cf89cccd2d93b6245e784c19afe0a9f5038d4528"
+  integrity sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ==
+
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz"
@@ -1344,10 +1463,22 @@ base-x@^4.0.0:
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
   integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 before-after-hook@^2.2.0:
   version "2.2.2"
   resolved "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz"
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
 
 bip39-light@^1.0.7:
   version "1.0.7"
@@ -1366,6 +1497,15 @@ bip39@3.0.2:
     create-hash "^1.1.0"
     pbkdf2 "^3.0.9"
     randombytes "^2.0.1"
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bn.js@5.2.1:
   version "5.2.1"
@@ -1453,6 +1593,14 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 cacheable-lookup@^5.0.3:
   version "5.0.4"
@@ -1543,6 +1691,11 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1862,6 +2015,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+detect-libc@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz#8ccf2ba9315350e1241b88d0ac3b0e1fbd99605d"
+  integrity sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz"
@@ -1913,7 +2071,7 @@ emoji-regex@^8.0.0:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -2047,6 +2205,11 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -2066,6 +2229,11 @@ exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
+
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
 expand-tilde@^2.0.2:
   version "2.0.2"
@@ -2133,6 +2301,11 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
@@ -2187,6 +2360,11 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-exists-sync@^0.1.0:
   version "0.1.0"
@@ -2265,6 +2443,11 @@ git-config-path@^1.0.1:
     extend-shallow "^2.0.1"
     fs-exists-sync "^0.1.0"
     homedir-polyfill "^1.0.0"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 glob-parent@^6.0.2:
   version "6.0.2"
@@ -2470,6 +2653,11 @@ hyperlinker@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
+
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.2.0:
   version "5.3.0"
@@ -3451,6 +3639,16 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minimist@^1.2.3:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
@@ -3465,6 +3663,11 @@ mustache@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.0.0.tgz#7f02465dbb5b435859d154831c032acdfbbefb31"
   integrity sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA==
+
+napi-build-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
+  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -3513,6 +3716,17 @@ near-hd-key@^1.2.1:
     create-hmac "1.1.7"
     tweetnacl "1.0.3"
 
+near-ledger-js@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/near-ledger-js/-/near-ledger-js-0.2.1.tgz#38afc88ad0cc9b70585632b7d70280ef9e47808a"
+  integrity sha512-8anZb6e96gJNBOKUR/HReLN/x8BmBhCpyPq+XxFbx8jxmsRz+M1Hxq085+ROYaMI2EDJqatrjjLAdArk13BOhA==
+  dependencies:
+    "@ledgerhq/hw-transport-u2f" "^5.36.0-deprecated"
+    "@ledgerhq/hw-transport-webhid" "^5.51.1"
+    "@ledgerhq/hw-transport-webusb" "^5.53.1"
+    bs58 "^4.0.1"
+    platform "^1.3.6"
+
 near-seed-phrase@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/near-seed-phrase/-/near-seed-phrase-0.2.0.tgz"
@@ -3522,6 +3736,23 @@ near-seed-phrase@^0.2.0:
     bs58 "^4.0.1"
     near-hd-key "^1.2.1"
     tweetnacl "^1.0.2"
+
+node-abi@^3.3.0:
+  version "3.56.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.56.0.tgz#ca807d5ff735ac6bbbd684ae3ff2debc1c2a40a7"
+  integrity sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==
+  dependencies:
+    semver "^7.3.5"
+
+node-addon-api@^3.0.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-addon-api@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
+  integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
 
 node-cleanup@^2.1.2:
   version "2.1.2"
@@ -3541,6 +3772,20 @@ node-fetch@^2.6.7:
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-gyp-build@^4.5.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.0.tgz#3fee9c1731df4581a3f9ead74664369ff00d26dd"
+  integrity sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==
+
+node-hid@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-2.2.0.tgz#33e039e7530a7bfe2b7a25f0a2f9496af8b02236"
+  integrity sha512-vj48zh9j555DZzUhMc8tk/qw6xPFrDyPBH1ST1Z/hWaA/juBJw7IuSxPeOgpzNFNU36mGYj+THioRMt1xOdm/g==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^3.0.2"
+    prebuild-install "^7.1.1"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3783,6 +4028,29 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+platform@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
+  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
+
+prebuild-install@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
@@ -3877,7 +4145,7 @@ randombytes@2.1.0, randombytes@^2.0.1:
   dependencies:
     safe-buffer "^5.1.0"
 
-rc@1.2.8, rc@^1.2.8:
+rc@1.2.8, rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -3891,6 +4159,15 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readable-stream@^3.6.0:
   version "3.6.0"
@@ -4017,6 +4294,20 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rxjs@6:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^7.8.1:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
@@ -4043,6 +4334,13 @@ semver@^7.3.4, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.5:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -4100,6 +4398,20 @@ signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -4257,6 +4569,27 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+tar-fs@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 tcp-port-used@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz"
@@ -4311,6 +4644,23 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
+tslib@^1.9.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 tweetnacl@1.0.3, tweetnacl@^1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz"
@@ -4349,6 +4699,11 @@ typescript@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+
+u2f-api@0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/u2f-api/-/u2f-api-0.2.7.tgz#17bf196b242f6bf72353d9858e6a7566cc192720"
+  integrity sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg==
 
 unique-string@^2.0.0:
   version "2.0.0"
@@ -4403,6 +4758,15 @@ url-parse-lax@^3.0.0:
   integrity sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==
   dependencies:
     prepend-http "^2.0.0"
+
+usb@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/usb/-/usb-2.9.0.tgz#8ae3b175f93bee559400bff33491eee63406b6a2"
+  integrity sha512-G0I/fPgfHUzWH8xo2KkDxTTFruUWfppgSFJ+bQxz/kVY2x15EQ/XDB7dqD1G432G4gBG4jYQuF3U7j/orSs5nw==
+  dependencies:
+    "@types/w3c-web-usb" "^1.0.6"
+    node-addon-api "^6.0.0"
+    node-gyp-build "^4.5.0"
 
 util-deprecate@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR brings back Ledger support, that was removed while transitioning to v4.0.0. It uses the latest package version of Ledger Transport (used to talk with Ledger) and brings some improvements on error handling.

The most important change with respect to v3.5.0 is that the Ledger is now treated as a `util` instead of a `middleware`. This way, we can handle Ledger errors on the command, meaning that an error will print the Ledger error message, and NOT the (error message + stack trace + command help).

Finally, the commands where changed, now `useLedgerKey` is a boolean, and the path is set apart. This introduces no friction to the users using the default path (which we assume is the majority), making the commands fully retrocompatible with v3.5.0 for them.

Users that do select paths will need to use the `--ledgerPath` flag