### PR TITLE
fix: display warning on duplicated env vars

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,8 @@
-const DEFAULT_NETWORK = process.env.NEAR_ENV || process.env.NEAR_NETWORK || 'testnet';
+const DEFAULT_NETWORK = process.env.NEAR_NETWORK || process.env.NEAR_ENV || 'testnet';
+
+if (process.env.NEAR_NETWORK && process.env.NEAR_ENV){
+    console.log(`Warning: NEAR_NETWORK and NEAR_ENV are both set! We will use NEAR_NETWORK (${process.env.NEAR_NETWORK})\n`);
+}
 
 function getConfig(env) {
     let config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-cli",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "Simple CLI for interacting with NEAR Protocol",
   "engines": {
     "node": ">= 16"


### PR DESCRIPTION
Address #1107 

The `near-cli` now shows a warning:

`Warning: NEAR_NETWORK and NEAR_ENV are both set! We will use NEAR_NETWORK (${process.env.NEAR_NETWORK})`